### PR TITLE
Remove font size slider from formatting panel

### DIFF
--- a/components/panels/FormattingPanel.tsx
+++ b/components/panels/FormattingPanel.tsx
@@ -289,26 +289,6 @@ export function FormattingPanel({
             </div>
           </div>
 
-          {/* Font Size Slider */}
-          <div>
-            <input
-              type="range"
-              min="8"
-              max="72"
-              value={positions[selectedField]?.fontSize || DEFAULT_FONT_SIZE}
-              onChange={(e) => {
-                const newFontSize = parseInt(e.target.value);
-                setPositions((prev) => ({
-                  ...prev,
-                  [selectedField]: {
-                    ...prev[selectedField],
-                    fontSize: newFontSize
-                  }
-                }));
-              }}
-              className="w-full"
-            />
-          </div>
 
           {/* Text Color Picker */}
           <div>


### PR DESCRIPTION
## Summary
- Removed the redundant font size range slider from the FormattingPanel component
- Kept the number input field which provides more precise font size control (8-72px)
- Simplifies the UI by removing duplicate functionality

## Test plan
- [ ] Verify font size can still be adjusted using the number input field
- [ ] Ensure font size changes are reflected in the certificate preview
- [ ] Confirm the formatting panel layout looks clean without the slider

🤖 Generated with [Claude Code](https://claude.ai/code)