### PR TITLE
chore: remove Node 18.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Professional certificate generator with drag-and-drop text positioning, advanced formatting, and bulk PDF generation",
   "private": true,
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Add Node 20+ requirement to package.json via engines field
- Prepare for dropping Node 18.x support from CI

## Notes
- GitHub Actions workflow changes need to be applied separately due to permissions
- Node 18.x is in maintenance mode until April 2025, but Node 20.x is the current LTS

## Test plan
- [ ] Verify build still works with Node 20
- [ ] Update GitHub Actions workflow separately to remove Node 18.x from test matrix

🤖 Generated with [Claude Code](https://claude.ai/code)