### PR TITLE
Fix arrow key conflict when editing input fields

### DIFF
--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -21,6 +21,16 @@ export function useKeyboardShortcuts({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!selectedField || isDragging) return;
 
+      // Don't nudge if an input, textarea, or contenteditable element has focus
+      const activeElement = document.activeElement;
+      if (
+        activeElement?.tagName === 'INPUT' ||
+        activeElement?.tagName === 'TEXTAREA' ||
+        activeElement?.getAttribute('contenteditable') === 'true'
+      ) {
+        return;
+      }
+
       const nudgeAmount = event.shiftKey ? 2 : 0.5; // Larger nudge with Shift
 
       switch (event.key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,9 @@
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.4.0",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -116,6 +116,7 @@ Anastasiopolis Meridienne Calderón-Rutherford,Global Operations,c@c.com`
   const [currentTemplateName, setCurrentTemplateName] = useState<string | null>(
     null
   );
+  const [hasInputFocus, setHasInputFocus] = useState<boolean>(false);
 
   // Drag and drop hook
   const {
@@ -492,6 +493,39 @@ Anastasiopolis Meridienne Calderón-Rutherford,Global Operations,c@c.com`
     setEmailConfig,
     showToast
   ]);
+
+  // Track input focus state globally
+  useEffect(() => {
+    const handleFocusIn = (event: FocusEvent) => {
+      const target = event.target as HTMLElement;
+      if (
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.getAttribute('contenteditable') === 'true'
+      ) {
+        setHasInputFocus(true);
+      }
+    };
+
+    const handleFocusOut = (event: FocusEvent) => {
+      const target = event.target as HTMLElement;
+      if (
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.getAttribute('contenteditable') === 'true'
+      ) {
+        setHasInputFocus(false);
+      }
+    };
+
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
+  }, []);
 
   // Keyboard shortcuts hook
   useKeyboardShortcuts({
@@ -934,9 +968,10 @@ Email Sending Robot`,
                 {/* Arrow key hint - center aligned */}
                 {selectedField && (
                   <div className="flex items-center justify-center text-xs text-gray-500">
-                    <span>
-                      Use arrow keys to nudge selected text (Shift for larger
-                      steps)
+                    <span className={hasInputFocus ? "opacity-50" : ""}>
+                      {hasInputFocus 
+                        ? "Arrow key nudging disabled while editing"
+                        : "Use arrow keys to nudge selected text (Shift for larger steps)"}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Fixed arrow key nudging interfering with text field editing
- Arrow keys now work normally when any input field has focus
- UI hint updates to show when nudging is disabled

## Problem
When trying to edit numeric values in input fields (like font size), the arrow keys would trigger the nudging behavior instead of allowing normal text cursor movement. This made it difficult to edit values using keyboard navigation.

## Solution
1. Added a check in `useKeyboardShortcuts` hook to detect when an input, textarea, or contenteditable element has focus
2. Added global focus tracking in `index.tsx` to maintain state of whether any input has focus
3. Updated the UI hint to show different messages:
   - Normal: "Use arrow keys to nudge selected text (Shift for larger steps)"
   - Input focused: "Arrow key nudging disabled while editing" (with reduced opacity)

## Test plan
- [x] Select a text field on the certificate
- [x] Click on the font size input field
- [x] Verify arrow keys move cursor within the input instead of nudging the text position
- [x] Verify the hint message changes to indicate nudging is disabled
- [x] Click outside the input field
- [x] Verify arrow keys resume nudging behavior
- [x] Test with other input fields (color picker text input, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)