### PR TITLE
Fix: Template not found error on first generation

### DIFF
--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { IncomingForm, File, Fields, Files } from 'formidable';
 import storageConfig from '@/lib/storage-config';
 import { uploadToR2 } from '@/lib/r2-client';
-import { getTempImagesDir, getTemplateImagesDir, ensureAllDirectoriesExist } from '@/lib/paths';
+import { getTempImagesDir, ensureAllDirectoriesExist } from '@/lib/paths';
 
 export const config = {
   api: {
@@ -71,10 +71,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       });
     });
 
-    // Check if this is a template upload
-    const isTemplateField = fields.isTemplate;
-    const isTemplate = Array.isArray(isTemplateField) ? isTemplateField[0] === 'true' : isTemplateField === 'true';
-    
     // console.log('Files structure:', JSON.stringify(files, null, 2));
 
     const fileArray = files.template as File[] | File | undefined;
@@ -119,52 +115,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     
     let imageUrl: string;
     
-    // Determine where to save files based on whether this is a template
-    const templateDir = getTemplateImagesDir();
-    const localSaveDir = isTemplate && !storageConfig.isR2Enabled && !storageConfig.isS3Enabled 
-      ? templateDir 
-      : tempDir;
-    
-    // ALWAYS save PDF locally for the generate endpoint to use
-    const pdfFilepath = path.join(localSaveDir, pdfFilename);
+    // User uploads always go to temp_images (they're temporary)
+    // Only dev-mode templates go to template_images (permanent storage)
+    const pdfFilepath = path.join(tempDir, pdfFilename);
     await fsPromises.writeFile(pdfFilepath, pdfBytes);
     
     if (storageConfig.isR2Enabled) {
       console.log('Uploading to R2...');
       
       // Upload original image to R2 for display
-      const metadata = isTemplate ? {
-        type: 'template' as const,
-        retention: 'permanent' as const,
-        isTemplate: 'true'
-      } : undefined;
-      
       const uploadResult = await uploadToR2(
         Buffer.from(originalImageBytes),
         `temp_images/${imageName}`,
         mimetype,
-        imageName,
-        metadata
+        imageName
       );
       imageUrl = uploadResult.url;
       
       // Also save image locally as backup
-      const imageFilepath = path.join(localSaveDir, imageName);
+      const imageFilepath = path.join(tempDir, imageName);
       await fsPromises.copyFile(filepath, imageFilepath);
       
       console.log('R2 upload successful:', imageUrl);
     } else {
-      // Fallback to local storage
-      const imageFilepath = path.join(localSaveDir, imageName);
+      // Fallback to local storage - always use temp_images for user uploads
+      const imageFilepath = path.join(tempDir, imageName);
       await fsPromises.copyFile(filepath, imageFilepath);
-      
-      // Return appropriate URL based on where file was saved
-      if (isTemplate && localSaveDir === templateDir) {
-        // For templates saved locally, return direct path
-        imageUrl = `/template_images/${imageName}`;
-      } else {
-        imageUrl = storageConfig.getFileUrl(imageName, undefined, 'temp_images');
-      }
+      imageUrl = storageConfig.getFileUrl(imageName, undefined, 'temp_images');
     }
     
     console.log("imageUrl:", imageUrl);
@@ -173,7 +150,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       message: 'Template uploaded successfully',
       filename: pdfFilename,
       image: imageUrl,
-      isTemplate: isTemplate,
       storageType: storageConfig.isR2Enabled ? 'r2' : storageConfig.isS3Enabled ? 's3' : 'local'
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Fixed the "template not found" error that occurred on first PDF generation attempt
- Simplified file storage logic to properly separate dev templates from user uploads
- Enhanced error logging for better debugging

## Problem
When generating PDFs on the server, the first attempt would fail with "template not found", but the second attempt would work. This was due to inconsistent file storage paths between the upload and generate endpoints.

## Solution
- **Simplified upload.ts**: User uploads now consistently go to `temp_images/` directory only
- **Enhanced generate.ts**: Properly checks both directories (template_images for dev templates, temp_images for user uploads)
- **Removed unnecessary logic**: Eliminated the confusing isTemplate flag and dual-directory saves

## Architecture Clarification
The two-directory structure is intentional and necessary:
- `template_images/`: Permanent storage for dev mode templates (never cleaned up)
- `temp_images/`: Temporary storage for user uploads (cleaned after 30 days)

## Test Plan
- [ ] Upload a new certificate template
- [ ] Generate PDFs on first attempt - should work without "template not found" error
- [ ] Verify dev mode still works with pre-installed templates
- [ ] Confirm cleanup scripts still exclude template_images directory

🤖 Generated with [Claude Code](https://claude.ai/code)