### PR TITLE
feat: auto-select first visible field when created

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,9 @@
 ## Actual things I wanted to do. Maximum priority!
 
 - [x] ~~First time pressing "generate" after uploading and adding a text gives an error. Pressing generate after that works again though.~~ **FIXED!** 🎉 
-- [ ] We really should refactor all the "Template" names into "Project". It's getting confusing for the AI. 
+- [ ] We really should refactor all the "Template" names into "Project". It's getting confusing for the AI. But we have to be very careful not to over what else could be called a "template" in the so we don't just blindly change things! Also, beware the tests, which have lots of dependencies on these.-
+- [ ]I get the nagging feeling that there's a lot of confusion over server-side rendering and client-
+side rendering in the code. Does this need to be cleaned up?
 - [ ] When creating the first field on the preview panel, it should already be selected
 - [ ] Text field colour should adapt to the general tone of the background image. If it's a dark background, make a light colour for the text. 
 - [ ] We should have some kind of email download links; see below. 

--- a/TODO.md
+++ b/TODO.md
@@ -3,10 +3,9 @@
 ## Actual things I wanted to do. Maximum priority!
 
 - [x] ~~First time pressing "generate" after uploading and adding a text gives an error. Pressing generate after that works again though.~~ **FIXED!** 🎉 
-- [ ] We really should refactor all the "Template" names into "Project". It's getting confusing for the AI. But we have to be very careful not to over what else could be called a "template" in the so we don't just blindly change things! Also, beware the tests, which have lots of dependencies on these.-
-- [ ]I get the nagging feeling that there's a lot of confusion over server-side rendering and client-
-side rendering in the code. Does this need to be cleaned up?
-- [ ] When creating the first field on the preview panel, it should already be selected
+- [ ] We really should refactor all the "Template" names into "Project". It's getting confusing for the AI. But we have to be very careful not to overwrite what else could be called a "template" in the code, so we don't just blindly change things! Also, beware the tests, which have lots of dependencies on these.
+- [ ] I get the nagging feeling that there's a lot of confusion over server-side rendering and client-side rendering in the code. Does this need to be cleaned up?
+- [x] ~~When creating the first field on the preview panel, it should already be selected~~ **DONE!**
 - [ ] Text field colour should adapt to the general tone of the background image. If it's a dark background, make a light colour for the text. 
 - [ ] We should have some kind of email download links; see below. 
 

--- a/hooks/usePositioning.ts
+++ b/hooks/usePositioning.ts
@@ -17,6 +17,9 @@ export interface UsePositioningReturn {
 export function usePositioning({ tableData, setSelectedField }: UsePositioningProps): UsePositioningReturn {
   const [positions, setPositions] = useState<Positions>({});
 
+  // Track if we need to select the first field
+  const [shouldSelectFirst, setShouldSelectFirst] = useState<string | null>(null);
+
   // Ensure all table columns have positions
   useEffect(() => {
     if (tableData.length > 0) {
@@ -56,18 +59,23 @@ export function usePositioning({ tableData, setSelectedField }: UsePositioningPr
           }
         });
 
-        // If we created new positions and have a first visible field, select it
+        // If we created new positions and have a first visible field, mark it for selection
         if (hasNewPositions && firstVisibleField && setSelectedField) {
-          // Use setTimeout to ensure the state update happens after positions are set
-          setTimeout(() => {
-            setSelectedField(firstVisibleField);
-          }, 0);
+          setShouldSelectFirst(firstVisibleField);
         }
 
         return hasNewPositions ? newPositions : prevPositions;
       });
     }
   }, [tableData, setSelectedField]);
+
+  // Select the first field in a separate effect to avoid timing issues
+  useEffect(() => {
+    if (shouldSelectFirst && setSelectedField) {
+      setSelectedField(shouldSelectFirst);
+      setShouldSelectFirst(null);
+    }
+  }, [shouldSelectFirst, setSelectedField]);
 
   // Helper function to change alignment while keeping visual position
   const changeAlignment = useCallback(

--- a/hooks/usePositioning.ts
+++ b/hooks/usePositioning.ts
@@ -4,6 +4,7 @@ import type { TableData, Position, Positions, TextAlignment } from "@/types/cert
 
 export interface UsePositioningProps {
   tableData: TableData[];
+  setSelectedField?: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
 export interface UsePositioningReturn {
@@ -13,7 +14,7 @@ export interface UsePositioningReturn {
   clearPositions: () => void;
 }
 
-export function usePositioning({ tableData }: UsePositioningProps): UsePositioningReturn {
+export function usePositioning({ tableData, setSelectedField }: UsePositioningProps): UsePositioningReturn {
   const [positions, setPositions] = useState<Positions>({});
 
   // Ensure all table columns have positions
@@ -22,6 +23,7 @@ export function usePositioning({ tableData }: UsePositioningProps): UsePositioni
       setPositions((prevPositions) => {
         const newPositions = { ...prevPositions };
         let hasNewPositions = false;
+        let firstVisibleField: string | null = null;
 
         Object.keys(tableData[0]).forEach((key, index) => {
           if (!newPositions[key]) {
@@ -31,6 +33,8 @@ export function usePositioning({ tableData }: UsePositioningProps): UsePositioni
               key.toLowerCase().includes("e-mail") ||
               key.toLowerCase().includes("mail");
 
+            const isVisible = !isEmailField;
+            
             newPositions[key] = {
               x: 50,
               y: 50 + index * 10,
@@ -38,19 +42,32 @@ export function usePositioning({ tableData }: UsePositioningProps): UsePositioni
               fontFamily: "Helvetica",
               color: "#000000",
               alignment: "center",
-              isVisible: !isEmailField, // Hide email fields by default
+              isVisible, // Hide email fields by default
               width: 90, // Default to 90% width
               textMode: "shrink", // Default to shrink-to-fit mode
               lineHeight: 1.2
             };
             hasNewPositions = true;
+            
+            // Track the first visible field
+            if (isVisible && !firstVisibleField) {
+              firstVisibleField = key;
+            }
           }
         });
+
+        // If we created new positions and have a first visible field, select it
+        if (hasNewPositions && firstVisibleField && setSelectedField) {
+          // Use setTimeout to ensure the state update happens after positions are set
+          setTimeout(() => {
+            setSelectedField(firstVisibleField);
+          }, 0);
+        }
 
         return hasNewPositions ? newPositions : prevPositions;
       });
     }
-  }, [tableData]);
+  }, [tableData, setSelectedField]);
 
   // Helper function to change alignment while keeping visual position
   const changeAlignment = useCallback(

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -111,10 +111,12 @@ export default function HomePage() {
   // CUSTOM HOOKS FOR FEATURE MANAGEMENT
   // ============================================================================
 
+  // Selected field state (needs to be before usePositioning)
+  const [selectedField, setSelectedField] = useState<string | null>(null);
+  
   // Positioning hook
   const { positions, setPositions, changeAlignment, clearPositions } =
-    usePositioning({ tableData });
-  const [selectedField, setSelectedField] = useState<string | null>(null);
+    usePositioning({ tableData, setSelectedField });
   const [activeTab, setActiveTab] = useState<"data" | "formatting" | "email">(
     "data"
   );


### PR DESCRIPTION
## Summary
- Automatically selects the first visible text field when fields are created on the certificate preview
- Improves UX by eliminating the need for an extra click to start formatting

## Changes
- Modified `usePositioning` hook to accept optional `setSelectedField` parameter
- Track first visible field during position initialization (email fields are hidden by default)
- Auto-select first visible field after positions are created
- Reorganized state initialization in main page to pass `setSelectedField` to the hook

## Test Plan
- [x] Upload a certificate template image
- [x] Add data (via paste or Dev Mode)
- [x] Verify first non-email field is automatically selected (green border)
- [x] Verify formatting panel shows controls for the selected field
- [x] Verify email fields remain hidden and unselected

🤖 Generated with [Claude Code](https://claude.ai/code)