### PR TITLE
Auto-adapt text color to background luminance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,8 @@
     - Updated `usePdfGenerationMethods` hook to prioritize client-side
     - Added clear documentation and legacy markers to all server-side code
     - Updated CLAUDE.md and CLIENT_SIDE_PDF.md to reflect this philosophy
-- [ ] Text field colour should adapt to the general tone of the background image. If it's a dark background, make a light colour for the text.
+- [x] ✅ Text field colour should adapt to the general tone of the background image. If it's a dark background, make a light colour for the text.
+  - COMPLETED: On image load, the app analyzes average image luminance and auto-sets default text colours to ensure contrast (white on dark images, black on light images). Existing custom colours are preserved; only default black/white values are adapted.
 - [ ] We should have some kind of email download links; see below.
 
 ## Future Enhancement: Email Download Links for Client-Side PDFs

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -212,7 +212,7 @@ export default function HomePage() {
             const current = next[key];
             if (!current) return;
             const currentColor = (current.color || '').toLowerCase();
-            if (current.color === undefined || currentColor === defaultBlack) {
+            if (current.color === undefined || currentColor === defaultBlack || currentColor === '') {
               // untouched or default black -> apply auto color
               next[key] = { ...current, color: autoColor };
               changed = true;

--- a/utils/imageAnalysis.ts
+++ b/utils/imageAnalysis.ts
@@ -1,0 +1,59 @@
+// Lightweight image analysis utilities
+
+/**
+ * Compute the average luminance of an image by drawing it to a small
+ * offscreen canvas and averaging pixel values. Returns a number in [0, 255].
+ */
+export async function getImageAverageLuminance(imageUrl: string): Promise<number> {
+  if (!imageUrl) return 255; // default to light
+
+  // Wrap in a Promise to resolve after image load/draw
+  return new Promise((resolve) => {
+    try {
+      const img = new Image();
+      // Same-origin or blob URLs should work; keep anonymous to avoid tainting
+      img.crossOrigin = 'anonymous';
+      img.onload = () => {
+        try {
+          const targetSize = 32; // small sample for speed
+          const w = Math.max(1, Math.min(targetSize, img.width));
+          const h = Math.max(1, Math.min(targetSize, img.height));
+          const canvas = document.createElement('canvas');
+          canvas.width = w;
+          canvas.height = h;
+          const ctx = canvas.getContext('2d');
+          if (!ctx) return resolve(255);
+          // Draw scaled image to canvas
+          ctx.drawImage(img, 0, 0, w, h);
+          const data = ctx.getImageData(0, 0, w, h).data;
+
+          let sum = 0;
+          const totalPixels = w * h;
+          for (let i = 0; i < data.length; i += 4) {
+            const r = data[i];
+            const g = data[i + 1];
+            const b = data[i + 2];
+            // Perceived luminance (Rec. 709)
+            const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            sum += lum;
+          }
+          resolve(sum / totalPixels);
+        } catch {
+          resolve(255);
+        }
+      };
+      img.onerror = () => resolve(255);
+      img.src = imageUrl;
+    } catch {
+      resolve(255);
+    }
+  });
+}
+
+/**
+ * Given a luminance in [0, 255], return a readable text color.
+ * Dark backgrounds (< 128) -> white text, else black text.
+ */
+export function getReadableTextColorForLuminance(luminance: number): '#ffffff' | '#000000' {
+  return luminance < 128 ? '#ffffff' : '#000000';
+}


### PR DESCRIPTION
Implements adaptive text color selection based on the uploaded certificate background image.\n\nSummary\n- Adds utils/imageAnalysis.ts to sample image and compute average luminance.\n- On image load, auto-sets text colors to white/black for readability.\n- Preserves user-selected custom colors; only defaults are adapted.\n- Updates TODO.md to mark the task complete.\n\nFiles\n- pages/index.tsx\n- utils/imageAnalysis.ts\n- TODO.md\n\nNotes\n- Threshold: luminance < 128 -> #ffffff, else #000000.\n- Works with blob and same-origin URLs; silently no-ops on errors.