### PR TITLE
Fix: Allow super admins to access storage APIs in production

### DIFF
--- a/pages/api/dev-cleanup.ts
+++ b/pages/api/dev-cleanup.ts
@@ -141,8 +141,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!isDevelopment) {
     // Check if user is super admin
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user?.email) {
-      res.status(401).json({ error: 'Unauthorized' });
+
+    // Validate session exists and has required user data
+    // getServerSession validates JWT token expiry and signature internally
+    if (!session || !session.user || !session.user.email || !session.user.id) {
+      res.status(401).json({ error: 'Unauthorized - valid session required' });
       return;
     }
 

--- a/pages/api/storage-stats.ts
+++ b/pages/api/storage-stats.ts
@@ -2,6 +2,9 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
 import { getTempImagesDir, getGeneratedDir } from '@/lib/paths';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+import { detectUserTier } from '@/lib/server/tiers';
 
 interface FileInfo {
   name: string;
@@ -144,10 +147,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // Only allow in development mode for security
-  if (process.env.NODE_ENV !== 'development') {
-    res.status(403).json({ error: 'Only available in development mode' });
-    return;
+  // Allow in development mode OR for super admins in production
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  if (!isDevelopment) {
+    // Check if user is super admin
+    const session = await getServerSession(req, res, authOptions);
+    if (!session?.user?.email) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+
+    const userTier = detectUserTier(session.user.email);
+    if (userTier !== 'super_admin') {
+      res.status(403).json({ error: 'Only available for super admins in production' });
+      return;
+    }
   }
 
   try {

--- a/pages/api/storage-stats.ts
+++ b/pages/api/storage-stats.ts
@@ -153,8 +153,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!isDevelopment) {
     // Check if user is super admin
     const session = await getServerSession(req, res, authOptions);
-    if (!session?.user?.email) {
-      res.status(401).json({ error: 'Unauthorized' });
+
+    // Validate session exists and has required user data
+    // getServerSession validates JWT token expiry and signature internally
+    if (!session || !session.user || !session.user.email || !session.user.id) {
+      res.status(401).json({ error: 'Unauthorized - valid session required' });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fixed 403 Forbidden error when super admins try to use storage monitoring in production
- Storage stats and cleanup APIs now properly authenticate super admin users
- Dev Mode footer storage features now work for super admins in production

## Problem
When super admins access the Dev Mode footer in production, the storage monitor shows "Loading storage..." indefinitely due to the APIs returning 403 Forbidden. This was because the APIs only checked for development mode, not super admin status.

## Solution
Updated both `/api/storage-stats` and `/api/dev-cleanup` endpoints to:
1. Check if running in development mode (existing behavior)
2. If in production, authenticate the user session
3. Allow access if user tier is `super_admin`

## Test Plan
- [x] Verify storage monitor works in development mode
- [ ] Deploy to production and verify super admin can see storage stats
- [ ] Verify non-super-admin users still get 403 in production
- [ ] Test cleanup functionality works for super admins

🤖 Generated with [Claude Code](https://claude.ai/code)