### PR TITLE
Stop automatic text-color render loop

### DIFF
--- a/__tests__/components/modals/ConfirmationModals.test.tsx
+++ b/__tests__/components/modals/ConfirmationModals.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ConfirmationModals } from '@/components/modals/ConfirmationModals';
+import type { Positions } from '@/types/certificate';
+
+const positions: Positions = {
+  Name: {
+    x: 50,
+    y: 50,
+    color: '#123456',
+    isColorAutomatic: false
+  },
+  Course: {
+    x: 50,
+    y: 60,
+    color: '#123456',
+    isColorAutomatic: false
+  }
+};
+
+describe('ConfirmationModals automatic colour reset', () => {
+  it('uses the analysed background colour when resetting one field', () => {
+    const setPositions = jest.fn();
+
+    render(
+      <ConfirmationModals
+        showResetFieldModal
+        setShowResetFieldModal={jest.fn()}
+        showClearAllModal={false}
+        setShowClearAllModal={jest.fn()}
+        selectedField="Name"
+        positions={positions}
+        setPositions={setPositions}
+        tableData={[{ Name: 'Ada', Course: 'Math' }]}
+        automaticTextColor="#ffffff"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    const update = setPositions.mock.calls[0][0];
+    const result = update(positions) as Positions;
+    expect(result.Name.color).toBe('#ffffff');
+    expect(result.Name.isColorAutomatic).toBe(true);
+  });
+
+  it('uses the analysed background colour when clearing all formatting', () => {
+    const setPositions = jest.fn();
+
+    render(
+      <ConfirmationModals
+        showResetFieldModal={false}
+        setShowResetFieldModal={jest.fn()}
+        showClearAllModal
+        setShowClearAllModal={jest.fn()}
+        selectedField="Name"
+        positions={positions}
+        setPositions={setPositions}
+        tableData={[{ Name: 'Ada', Course: 'Math' }]}
+        automaticTextColor="#ffffff"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear All' }));
+
+    const result = setPositions.mock.calls[0][0] as Positions;
+    expect(result.Name.color).toBe('#ffffff');
+    expect(result.Course.color).toBe('#ffffff');
+    expect(result.Name.isColorAutomatic).toBe(true);
+    expect(result.Course.isColorAutomatic).toBe(true);
+  });
+});

--- a/__tests__/hooks/useProjectManagement.test.ts
+++ b/__tests__/hooks/useProjectManagement.test.ts
@@ -45,6 +45,7 @@ const createProps = () => ({
   positions: {},
   emailConfig,
   tableData: [],
+  automaticTextColorResult: null,
   clearFile: jest.fn(),
   clearPositions: jest.fn(),
   clearDragState: jest.fn(),
@@ -83,5 +84,75 @@ describe('useProjectManagement colour provenance migration', () => {
       }
     });
     expect(ProjectStorage.updateProject).not.toHaveBeenCalled();
+  });
+
+  it('reapplies the cached automatic colour when project positions are replaced', async () => {
+    const props = {
+      ...createProps(),
+      automaticTextColorResult: {
+        imageUrl: legacyProject.certificateImage.url,
+        color: '#ffffff' as const
+      }
+    };
+
+    renderHook(() => useProjectManagement(props));
+
+    await waitFor(() => expect(props.setPositions).toHaveBeenCalled());
+    expect(props.setPositions).toHaveBeenCalledWith({
+      Name: {
+        ...legacyProject.positions.Name,
+        color: '#ffffff',
+        isColorAutomatic: true
+      }
+    });
+  });
+
+  it('does not apply a cached colour from a different project image', async () => {
+    const props = {
+      ...createProps(),
+      automaticTextColorResult: {
+        imageUrl: '/different-certificate.png',
+        color: '#ffffff' as const
+      }
+    };
+
+    renderHook(() => useProjectManagement(props));
+
+    await waitFor(() => expect(props.setPositions).toHaveBeenCalled());
+    expect(props.setPositions).toHaveBeenCalledWith({
+      Name: {
+        ...legacyProject.positions.Name,
+        isColorAutomatic: true
+      }
+    });
+  });
+
+  it('does not rerun startup loading when the cached colour changes', async () => {
+    const props = createProps();
+    const { rerender } = renderHook(
+      ({ automaticTextColorResult }) =>
+        useProjectManagement({ ...props, automaticTextColorResult }),
+      {
+        initialProps: {
+          automaticTextColorResult: null as {
+            imageUrl: string;
+            color: '#ffffff' | '#000000';
+          } | null
+        }
+      }
+    );
+
+    await waitFor(() =>
+      expect(ProjectStorage.getMostRecentProject).toHaveBeenCalledTimes(1)
+    );
+
+    rerender({
+      automaticTextColorResult: {
+        imageUrl: legacyProject.certificateImage.url,
+        color: '#ffffff'
+      }
+    });
+
+    expect(ProjectStorage.getMostRecentProject).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/hooks/useProjectManagement.test.ts
+++ b/__tests__/hooks/useProjectManagement.test.ts
@@ -1,0 +1,87 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useProjectManagement } from '@/hooks/useProjectManagement';
+import { ProjectStorage, type SavedProject } from '@/lib/project-storage';
+import { SessionStorage } from '@/lib/session-storage';
+import type { EmailConfig } from '@/types/certificate';
+
+const legacyProject: SavedProject = {
+  id: 'legacy-project',
+  name: 'Legacy project',
+  created: '2025-01-01T00:00:00.000Z',
+  lastModified: '2025-01-01T00:00:00.000Z',
+  version: '1.0',
+  positions: {
+    Name: { x: 50, y: 50, color: '#000000' }
+  },
+  columns: ['Name'],
+  tableData: [{ Name: 'Ada' }],
+  certificateImage: {
+    url: '/certificate.png',
+    filename: 'certificate.png',
+    uploadedAt: '2025-01-01T00:00:00.000Z',
+    isCloudStorage: false
+  }
+};
+
+const emailConfig: EmailConfig = {
+  senderName: '',
+  subject: '',
+  message: '',
+  deliveryMethod: 'download',
+  isConfigured: false
+};
+
+const createProps = () => ({
+  setPositions: jest.fn(),
+  setEmailConfig: jest.fn(),
+  setUploadedFileUrl: jest.fn(),
+  setUploadedFile: jest.fn(),
+  loadSessionData: jest.fn().mockResolvedValue(undefined),
+  uploadToServer: jest.fn().mockResolvedValue(undefined),
+  showToast: jest.fn(),
+  manualSave: jest.fn().mockResolvedValue({ success: true }),
+  uploadedFileUrl: null,
+  uploadedFile: null,
+  positions: {},
+  emailConfig,
+  tableData: [],
+  clearFile: jest.fn(),
+  clearPositions: jest.fn(),
+  clearDragState: jest.fn(),
+  clearData: jest.fn()
+});
+
+describe('useProjectManagement colour provenance migration', () => {
+  beforeEach(() => {
+    jest.spyOn(ProjectStorage, 'migrateFromTemplateStorage').mockReturnValue({
+      migrated: 0,
+      errors: 0
+    });
+    jest.spyOn(ProjectStorage, 'getMostRecentProject').mockResolvedValue(
+      legacyProject
+    );
+    jest.spyOn(SessionStorage, 'loadSession').mockReturnValue(null);
+    jest.spyOn(ProjectStorage, 'updateProject').mockResolvedValue({
+      success: true
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('defers persistence to autosave instead of writing during project load', async () => {
+    const props = createProps();
+
+    renderHook(() => useProjectManagement(props));
+
+    await waitFor(() => expect(props.setPositions).toHaveBeenCalled());
+    expect(props.setPositions).toHaveBeenCalledWith({
+      Name: {
+        ...legacyProject.positions.Name,
+        isColorAutomatic: true
+      }
+    });
+    expect(ProjectStorage.updateProject).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/utils/imageAnalysis.test.ts
+++ b/__tests__/utils/imageAnalysis.test.ts
@@ -4,8 +4,8 @@ import {
   getImageAverageLuminance,
   getReadableTextColorForLuminance,
   normalizeAutomaticTextColorProvenance
-} from '../../utils/imageAnalysis';
-import type { Positions } from '../../types/certificate';
+} from '@/utils/imageAnalysis';
+import type { Positions } from '@/types/certificate';
 
 const createPositions = (colors: Record<string, string | undefined>): Positions =>
   Object.fromEntries(

--- a/__tests__/utils/imageAnalysis.test.ts
+++ b/__tests__/utils/imageAnalysis.test.ts
@@ -1,0 +1,210 @@
+import {
+  applyAutomaticTextColor,
+  calculateAverageLuminance,
+  getImageAverageLuminance,
+  getReadableTextColorForLuminance,
+  normalizeAutomaticTextColorProvenance
+} from '../../utils/imageAnalysis';
+import type { Positions } from '../../types/certificate';
+
+const createPositions = (colors: Record<string, string | undefined>): Positions =>
+  Object.fromEntries(
+    Object.entries(colors).map(([key, color], index) => [
+      key,
+      {
+        x: 50,
+        y: 50 + index * 10,
+        color,
+        isColorAutomatic: true
+      }
+    ])
+  );
+
+describe('applyAutomaticTextColor', () => {
+  it('preserves object identity when the automatic colour is already applied', () => {
+    const positions = createPositions({ Name: '#000000', Course: '#000000' });
+
+    const result = applyAutomaticTextColor(
+      positions,
+      ['Name', 'Course'],
+      '#000000'
+    );
+
+    expect(result).toBe(positions);
+  });
+
+  it('updates default colours while preserving unrelated position properties', () => {
+    const positions = createPositions({ Name: '#000000', Course: '#ffffff' });
+
+    const result = applyAutomaticTextColor(
+      positions,
+      ['Name', 'Course'],
+      '#ffffff'
+    );
+
+    expect(result).not.toBe(positions);
+    expect(result.Name).toEqual({ ...positions.Name, color: '#ffffff' });
+    expect(result.Course).toBe(positions.Course);
+  });
+
+  it('does not overwrite any fields when a custom colour is present', () => {
+    const positions = createPositions({ Name: '#123456', Course: '#000000' });
+
+    const result = applyAutomaticTextColor(
+      positions,
+      ['Name', 'Course'],
+      '#ffffff'
+    );
+
+    expect(result).toBe(positions);
+  });
+
+  it('does not overwrite an explicit black or white selection', () => {
+    const positions = createPositions({ Name: '#000000', Course: '#000000' });
+    positions.Name = { ...positions.Name, isColorAutomatic: false };
+
+    const result = applyAutomaticTextColor(
+      positions,
+      ['Name', 'Course'],
+      '#ffffff'
+    );
+
+    expect(result).toBe(positions);
+  });
+
+  it('ignores custom colours retained for removed columns', () => {
+    const positions = createPositions({
+      Name: '#000000',
+      RemovedColumn: '#123456'
+    });
+
+    const result = applyAutomaticTextColor(
+      positions,
+      ['Name'],
+      '#ffffff'
+    );
+
+    expect(result.Name.color).toBe('#ffffff');
+    expect(result.RemovedColumn).toBe(positions.RemovedColumn);
+  });
+
+  it('applies an explicit default once to fields without a colour', () => {
+    const positions = createPositions({ Name: undefined });
+    const firstResult = applyAutomaticTextColor(positions, ['Name'], '#000000');
+    const secondResult = applyAutomaticTextColor(firstResult, ['Name'], '#000000');
+
+    expect(firstResult.Name.color).toBe('#000000');
+    expect(secondResult).toBe(firstResult);
+  });
+
+  it('skips columns without a corresponding position', () => {
+    const positions = createPositions({ Name: '#000000' });
+
+    const result = applyAutomaticTextColor(
+      positions,
+      ['Missing'],
+      '#ffffff'
+    );
+
+    expect(result).toBe(positions);
+  });
+
+  it('normalises colour case before comparing automatic colours', () => {
+    const positions = createPositions({ Name: '#FFFFFF' });
+
+    const result = applyAutomaticTextColor(positions, ['Name'], '#ffffff');
+
+    expect(result).toBe(positions);
+  });
+});
+
+describe('image luminance', () => {
+  it('composites transparent pixels over white', () => {
+    const pixels = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      0, 0, 0, 0
+    ]);
+
+    expect(calculateAverageLuminance(pixels)).toBeCloseTo(127.5);
+  });
+
+  it('returns null when there are no pixels or no image URL', async () => {
+    expect(calculateAverageLuminance(new Uint8ClampedArray())).toBeNull();
+    await expect(getImageAverageLuminance('')).resolves.toBeNull();
+  });
+
+  it('uses 128 as the light-background threshold', () => {
+    expect(getReadableTextColorForLuminance(127.99)).toBe('#ffffff');
+    expect(getReadableTextColorForLuminance(128)).toBe('#000000');
+  });
+});
+
+describe('normalizeAutomaticTextColorProvenance', () => {
+  it('marks legacy default colours as automatic', () => {
+    const positions = createPositions({ Name: '#000000', Course: '#ffffff' });
+    delete positions.Name.isColorAutomatic;
+    delete positions.Course.isColorAutomatic;
+
+    const result = normalizeAutomaticTextColorProvenance(
+      positions,
+      ['Name', 'Course']
+    );
+
+    expect(result).not.toBe(positions);
+    expect(result.Name.isColorAutomatic).toBe(true);
+    expect(result.Course.isColorAutomatic).toBe(true);
+  });
+
+  it('marks legacy colours as manual when any current colour is custom', () => {
+    const positions = createPositions({ Name: '#123456', Course: '#000000' });
+    delete positions.Name.isColorAutomatic;
+    delete positions.Course.isColorAutomatic;
+
+    const result = normalizeAutomaticTextColorProvenance(
+      positions,
+      ['Name', 'Course']
+    );
+
+    expect(result.Name.isColorAutomatic).toBe(false);
+    expect(result.Course.isColorAutomatic).toBe(false);
+  });
+
+  it('preserves identity when provenance is already present', () => {
+    const positions = createPositions({ Name: '#000000' });
+
+    const result = normalizeAutomaticTextColorProvenance(positions, ['Name']);
+
+    expect(result).toBe(positions);
+  });
+
+  it('normalizes retained legacy fields before they are reintroduced', () => {
+    const positions = createPositions({
+      Name: '#000000',
+      RemovedDefault: '#ffffff',
+      RemovedCustom: '#123456'
+    });
+    Object.values(positions).forEach((position) => {
+      delete position.isColorAutomatic;
+    });
+
+    const normalized = normalizeAutomaticTextColorProvenance(
+      positions,
+      ['Name']
+    );
+
+    expect(normalized.RemovedDefault.isColorAutomatic).toBe(true);
+    expect(normalized.RemovedCustom.isColorAutomatic).toBe(false);
+
+    const reintroducedDefaults = {
+      Name: normalized.Name,
+      RemovedDefault: normalized.RemovedDefault
+    };
+    const adjusted = applyAutomaticTextColor(
+      reintroducedDefaults,
+      ['Name', 'RemovedDefault'],
+      '#ffffff'
+    );
+    expect(adjusted.Name.color).toBe('#ffffff');
+    expect(adjusted.RemovedDefault.color).toBe('#ffffff');
+  });
+});

--- a/components/modals/ConfirmationModals.tsx
+++ b/components/modals/ConfirmationModals.tsx
@@ -12,8 +12,11 @@ export function ConfirmationModals({
   selectedField,
   positions,
   setPositions,
-  tableData
+  tableData,
+  automaticTextColor
 }: ConfirmationModalsProps) {
+  const resetTextColor = automaticTextColor || "#000000";
+
   return (
     <>
       {/* Reset Field Confirmation Modal */}
@@ -45,7 +48,8 @@ export function ConfirmationModals({
                     fontFamily: "Helvetica",
                     bold: false,
                     italic: false,
-                    color: "#000000",
+                    color: resetTextColor,
+                    isColorAutomatic: true,
                     alignment: "left"
                   }
                 }));
@@ -92,7 +96,8 @@ export function ConfirmationModals({
                       fontFamily: "Helvetica",
                       bold: false,
                       italic: false,
-                      color: "#000000",
+                      color: resetTextColor,
+                      isColorAutomatic: true,
                       alignment: "left"
                     };
                   }

--- a/components/panels/FormattingPanel.tsx
+++ b/components/panels/FormattingPanel.tsx
@@ -423,7 +423,8 @@ export function FormattingPanel({
                       ...prev,
                       [selectedField]: {
                         ...prev[selectedField],
-                        color: e.target.value
+                        color: e.target.value,
+                        isColorAutomatic: false
                       }
                     }));
                   }}
@@ -480,6 +481,8 @@ export function FormattingPanel({
                         bold: currentFormatting.bold,
                         italic: currentFormatting.italic,
                         color: currentFormatting.color,
+                        isColorAutomatic:
+                          currentFormatting.isColorAutomatic ?? false,
                         alignment: currentFormatting.alignment,
                         textMode: currentFormatting.textMode,
                         width: currentFormatting.width

--- a/hooks/usePositioning.ts
+++ b/hooks/usePositioning.ts
@@ -44,6 +44,7 @@ export function usePositioning({ tableData, setSelectedField }: UsePositioningPr
               fontSize: DEFAULT_FONT_SIZE,
               fontFamily: "Helvetica",
               color: "#000000",
+              isColorAutomatic: true,
               alignment: "center",
               isVisible, // Hide email fields by default
               width: 90, // Default to 90% width

--- a/hooks/useProjectManagement.tsx
+++ b/hooks/useProjectManagement.tsx
@@ -3,6 +3,7 @@ import type { SavedProject } from "@/lib/project-storage";
 import type { EmailConfig, TableData } from "@/types/certificate";
 import { ProjectStorage } from "@/lib/project-storage";
 import { SessionStorage } from "@/lib/session-storage";
+import { normalizeAutomaticTextColorProvenance } from "@/utils/imageAnalysis";
 
 interface UseProjectManagementProps {
   // State setters
@@ -97,6 +98,16 @@ export function useProjectManagement({
   const [showLoadProjectModal, setShowLoadProjectModal] = useState<boolean>(false);
   const [showNewProjectModal, setShowNewProjectModal] = useState<boolean>(false);
 
+  const loadProjectPositions = useCallback((project: SavedProject) => {
+    const normalizedPositions = normalizeAutomaticTextColorProvenance(
+      project.positions,
+      project.columns
+    );
+    setPositions(normalizedPositions);
+    // The normal autosave persists migrated provenance. Avoid a write-on-load
+    // that could race with edits or change the project's modified timestamp.
+  }, [setPositions]);
+
   // Load most recent project and session data on startup
   useEffect(() => {
     const loadStartupData = async () => {
@@ -140,7 +151,7 @@ export function useProjectManagement({
           console.log("Loading most recent project:", project.name);
 
           // Load the positions
-          setPositions(project.positions);
+          loadProjectPositions(project);
 
           // Load email configuration if present
           if (project.emailConfig) {
@@ -175,7 +186,7 @@ export function useProjectManagement({
   }, [
     loadSessionData,
     setEmailConfig,
-    setPositions,
+    loadProjectPositions,
     setUploadedFile,
     setUploadedFileUrl,
     showToast
@@ -185,7 +196,7 @@ export function useProjectManagement({
   const handleLoadProject = useCallback(
     async (project: SavedProject) => {
       // Load the positions
-      setPositions(project.positions);
+      loadProjectPositions(project);
 
       // Load the table data
       if (project.tableData && project.tableData.length > 0) {
@@ -232,7 +243,7 @@ export function useProjectManagement({
       console.log("Project loaded successfully:", project.name);
     },
     [
-      setPositions,
+      loadProjectPositions,
       setEmailConfig,
       setUploadedFileUrl,
       setUploadedFile,

--- a/hooks/useProjectManagement.tsx
+++ b/hooks/useProjectManagement.tsx
@@ -3,7 +3,10 @@ import type { SavedProject } from "@/lib/project-storage";
 import type { EmailConfig, TableData } from "@/types/certificate";
 import { ProjectStorage } from "@/lib/project-storage";
 import { SessionStorage } from "@/lib/session-storage";
-import { normalizeAutomaticTextColorProvenance } from "@/utils/imageAnalysis";
+import {
+  applyAutomaticTextColor,
+  normalizeAutomaticTextColorProvenance
+} from "@/utils/imageAnalysis";
 
 interface UseProjectManagementProps {
   // State setters
@@ -30,6 +33,10 @@ interface UseProjectManagementProps {
   positions: any;
   emailConfig: EmailConfig;
   tableData: TableData[];
+  automaticTextColorResult: {
+    imageUrl: string;
+    color: '#ffffff' | '#000000';
+  } | null;
   
   // Clear functions
   clearFile: () => void;
@@ -69,6 +76,7 @@ export function useProjectManagement({
   positions,
   emailConfig,
   tableData,
+  automaticTextColorResult,
   clearFile,
   clearPositions,
   clearDragState,
@@ -79,6 +87,7 @@ export function useProjectManagement({
   const latestPositionsRef = useRef(positions);
   const latestTableDataRef = useRef(tableData);
   const latestEmailConfigRef = useRef(emailConfig);
+  const automaticTextColorResultRef = useRef(automaticTextColorResult);
 
   useEffect(() => {
     latestPositionsRef.current = positions;
@@ -91,6 +100,10 @@ export function useProjectManagement({
   useEffect(() => {
     latestEmailConfigRef.current = emailConfig;
   }, [emailConfig]);
+
+  useEffect(() => {
+    automaticTextColorResultRef.current = automaticTextColorResult;
+  }, [automaticTextColorResult]);
   const [currentProjectName, setCurrentProjectName] = useState<string | null>(null);
   const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
   const [hasManuallySaved, setHasManuallySaved] = useState<boolean>(false);
@@ -103,7 +116,16 @@ export function useProjectManagement({
       project.positions,
       project.columns
     );
-    setPositions(normalizedPositions);
+    const cachedAutomaticTextColor = automaticTextColorResultRef.current;
+    const adjustedPositions =
+      cachedAutomaticTextColor?.imageUrl === project.certificateImage.url
+        ? applyAutomaticTextColor(
+            normalizedPositions,
+            project.columns,
+            cachedAutomaticTextColor.color
+          )
+        : normalizedPositions;
+    setPositions(adjustedPositions);
     // The normal autosave persists migrated provenance. Avoid a write-on-load
     // that could race with edits or change the project's modified timestamp.
   }, [setPositions]);

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { useTable, Column } from "react-table";
 import { useTableData } from "@/hooks/useTableData";
-import type { TableData, Position } from "@/types/certificate";
+import type { TableData } from "@/types/certificate";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { usePreview } from "@/hooks/usePreview";
 import { useFileUpload } from "@/hooks/useFileUpload";
@@ -40,7 +40,11 @@ import { ErrorModal } from "@/components/ui/error-alert";
 import { MobileWarningScreen } from "@/components/MobileWarningScreen";
 import { useMobileDetection } from "@/hooks/useMobileDetection";
 import { COLORS, GRADIENTS } from "@/utils/styles";
-import { getImageAverageLuminance, getReadableTextColorForLuminance } from "@/utils/imageAnalysis";
+import {
+  applyAutomaticTextColor,
+  getImageAverageLuminance,
+  getReadableTextColorForLuminance
+} from "@/utils/imageAnalysis";
 import { SplitButton } from "@/components/ui/split-button";
 import { useToast, ToastContainer } from "@/components/ui/toast";
 import { useProjectAutosave } from "@/hooks/useProjectAutosave";
@@ -201,49 +205,51 @@ export default function HomePage() {
     uploadToServer
   } = useFileUpload();
 
-  // Adapt default text color to background tone when a new image is loaded
+  const tableColumnsKey = JSON.stringify(Object.keys(tableData[0] || {}));
+  const [automaticTextColorResult, setAutomaticTextColorResult] = useState<{
+    imageUrl: string;
+    color: '#ffffff' | '#000000';
+  } | null>(null);
+  const automaticTextColor =
+    automaticTextColorResult?.imageUrl === uploadedFileUrl
+      ? automaticTextColorResult.color
+      : null;
+
+  // Adapt default text color when the background or set of fields changes.
   useEffect(() => {
-    (async () => {
-      if (!uploadedFileUrl || tableData.length === 0) return;
+    if (!uploadedFileUrl) return;
+
+    const tableColumns = JSON.parse(tableColumnsKey) as string[];
+    if (tableColumns.length === 0) return;
+
+    let cancelled = false;
+
+    const updateAutomaticTextColor = async () => {
       try {
-        // If positions already contain any non-default colors, do not auto-adjust
-        const hasCustomColors = Object.values(positions || {}).some((p: Position) => {
-          const c = (p?.color || '').toLowerCase();
-          return c && c !== '#000000' && c !== '#ffffff';
-        });
-        if (hasCustomColors) return;
-
         const lum = await getImageAverageLuminance(uploadedFileUrl);
+        if (cancelled) return;
+        if (lum === null) return;
+
         const autoColor = getReadableTextColorForLuminance(lum); // '#000000' or '#ffffff'
-
-        setPositions((prev) => {
-          const next = { ...prev };
-          let changed = false;
-          const defaultBlack = '#000000';
-          const defaultWhite = '#ffffff';
-
-          // Only set auto color for fields that are at default color
-          Object.keys(tableData[0] || {}).forEach((key) => {
-            const current = next[key];
-            if (!current) return;
-            const currentColor = (current.color || '').toLowerCase();
-            if (current.color === undefined || currentColor === defaultBlack || currentColor === '') {
-              // untouched or default black -> apply auto color
-              next[key] = { ...current, color: autoColor };
-              changed = true;
-            } else if ((currentColor === defaultWhite || currentColor === defaultBlack) && currentColor !== autoColor) {
-              // If a prior auto applied simple black/white exists, keep adapting
-              next[key] = { ...current, color: autoColor };
-              changed = true;
-            }
-          });
-          return changed ? next : prev;
-        });
+        setAutomaticTextColorResult((previous) =>
+          previous?.imageUrl === uploadedFileUrl && previous.color === autoColor
+            ? previous
+            : { imageUrl: uploadedFileUrl, color: autoColor }
+        );
+        setPositions((prev) =>
+          applyAutomaticTextColor(prev, tableColumns, autoColor)
+        );
       } catch {
         // Ignore analysis errors silently
       }
-    })();
-  }, [uploadedFileUrl, tableData, setPositions, positions]);
+    };
+
+    void updateAutomaticTextColor();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [uploadedFileUrl, tableColumnsKey, setPositions]);
 
 
   // PDF generation hook (must come after file upload hook)
@@ -1028,6 +1034,7 @@ export default function HomePage() {
         positions={positions}
         setPositions={setPositions}
         tableData={tableData}
+        automaticTextColor={automaticTextColor}
       />
 
       {/* Project Modals */}

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -420,6 +420,7 @@ export default function HomePage() {
     positions,
     emailConfig,
     tableData,
+    automaticTextColorResult,
     clearFile,
     clearPositions,
     clearDragState,

--- a/types/certificate.ts
+++ b/types/certificate.ts
@@ -33,6 +33,7 @@ export interface Position {
   bold?: boolean;
   italic?: boolean;
   color?: string;
+  isColorAutomatic?: boolean; // Whether background analysis may adjust the colour
   alignment?: TextAlignment;
   isVisible?: boolean;
   textMode?: TextMode;      // "shrink" or "multiline"
@@ -161,6 +162,7 @@ export interface ConfirmationModalsProps {
   positions: Positions;
   setPositions: React.Dispatch<React.SetStateAction<Positions>>;
   tableData: TableData[];
+  automaticTextColor: '#ffffff' | '#000000' | null;
 }
 
 // Panel props interfaces

--- a/utils/imageAnalysis.ts
+++ b/utils/imageAnalysis.ts
@@ -1,11 +1,125 @@
 // Lightweight image analysis utilities
 
+import type { Positions } from '@/types/certificate';
+
+const DEFAULT_TEXT_COLORS = new Set(['', '#000000', '#ffffff']);
+
+/**
+ * Apply a background-derived colour without overwriting user-selected colours.
+ * Once any current field has a manual colour, automatic adjustment is disabled
+ * for the current field set. Stale positions from removed fields are ignored.
+ * Returns the original object when no field needs to change so callers can
+ * safely use this in a React state updater without triggering another render.
+ */
+export function applyAutomaticTextColor(
+  positions: Positions,
+  columns: string[],
+  autoColor: '#ffffff' | '#000000'
+): Positions {
+  const hasManualOrCustomColors = columns.some((key) => {
+    const position = positions[key];
+    if (!position) return false;
+
+    const color = (position.color || '').toLowerCase();
+    return position.isColorAutomatic !== true || !DEFAULT_TEXT_COLORS.has(color);
+  });
+
+  if (hasManualOrCustomColors) return positions;
+
+  let nextPositions: Positions | null = null;
+
+  for (const key of columns) {
+    const current = positions[key];
+    if (!current) continue;
+
+    const currentColor = (current.color || '').toLowerCase();
+    if (!DEFAULT_TEXT_COLORS.has(currentColor) || currentColor === autoColor) {
+      continue;
+    }
+
+    if (!nextPositions) nextPositions = { ...positions };
+    nextPositions[key] = {
+      ...current,
+      color: autoColor,
+      isColorAutomatic: true
+    };
+  }
+
+  return nextPositions || positions;
+}
+
+/**
+ * Add colour provenance to projects saved before the flag existed. This
+ * mirrors the legacy policy: black/white fields remain automatic only when
+ * none of the current fields has a custom or explicitly manual colour.
+ */
+export function normalizeAutomaticTextColorProvenance(
+  positions: Positions,
+  columns: string[]
+): Positions {
+  const currentColumns = columns.length > 0 ? columns : Object.keys(positions);
+  const currentColumnSet = new Set(currentColumns);
+  const legacyColumns = Object.keys(positions).filter(
+    (key) => positions[key] && positions[key].isColorAutomatic === undefined
+  );
+
+  if (legacyColumns.length === 0) return positions;
+
+  const legacyColorsWereAutomatic = currentColumns.every((key) => {
+    const position = positions[key];
+    if (!position) return true;
+
+    const color = (position.color || '').toLowerCase();
+    return position.isColorAutomatic !== false && DEFAULT_TEXT_COLORS.has(color);
+  });
+
+  const nextPositions = { ...positions };
+  for (const key of legacyColumns) {
+    const color = (positions[key].color || '').toLowerCase();
+    nextPositions[key] = {
+      ...positions[key],
+      isColorAutomatic: currentColumnSet.has(key)
+        ? legacyColorsWereAutomatic
+        : DEFAULT_TEXT_COLORS.has(color)
+    };
+  }
+
+  return nextPositions;
+}
+
+/**
+ * Average Rec. 709 luminance after compositing transparent pixels over white,
+ * matching how certificate images appear on the page.
+ */
+export function calculateAverageLuminance(
+  pixels: Uint8ClampedArray
+): number | null {
+  const totalPixels = Math.floor(pixels.length / 4);
+  if (totalPixels === 0) return null;
+
+  let sum = 0;
+
+  for (let i = 0; i < totalPixels * 4; i += 4) {
+    const alpha = pixels[i + 3] / 255;
+    const pixelLuminance =
+      0.2126 * pixels[i] +
+      0.7152 * pixels[i + 1] +
+      0.0722 * pixels[i + 2];
+    sum += alpha * pixelLuminance + (1 - alpha) * 255;
+  }
+
+  return sum / totalPixels;
+}
+
 /**
  * Compute the average luminance of an image by drawing it to a small
- * offscreen canvas and averaging pixel values. Returns a number in [0, 255].
+ * offscreen canvas and averaging pixel values. Returns null when the image
+ * cannot be analysed (for example, when a remote host blocks CORS access).
  */
-export async function getImageAverageLuminance(imageUrl: string): Promise<number> {
-  if (!imageUrl) return 255; // default to light
+export async function getImageAverageLuminance(
+  imageUrl: string
+): Promise<number | null> {
+  if (!imageUrl) return null;
 
   // Wrap in a Promise to resolve after image load/draw
   return new Promise((resolve) => {
@@ -22,30 +136,19 @@ export async function getImageAverageLuminance(imageUrl: string): Promise<number
           canvas.width = w;
           canvas.height = h;
           const ctx = canvas.getContext('2d');
-          if (!ctx) return resolve(255);
+          if (!ctx) return resolve(null);
           // Draw scaled image to canvas
           ctx.drawImage(img, 0, 0, w, h);
           const data = ctx.getImageData(0, 0, w, h).data;
-
-          let sum = 0;
-          const totalPixels = w * h;
-          for (let i = 0; i < data.length; i += 4) {
-            const r = data[i];
-            const g = data[i + 1];
-            const b = data[i + 2];
-            // Perceived luminance (Rec. 709)
-            const lum = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-            sum += lum;
-          }
-          resolve(sum / totalPixels);
+          resolve(calculateAverageLuminance(data));
         } catch {
-          resolve(255);
+          resolve(null);
         }
       };
-      img.onerror = () => resolve(255);
+      img.onerror = () => resolve(null);
       img.src = imageUrl;
     } catch {
-      resolve(255);
+      resolve(null);
     }
   });
 }


### PR DESCRIPTION
## Summary

- stop automatic text-colour analysis from rerunning on every position update
- preserve explicit black/white choices with per-field colour provenance and legacy normalization
- keep resets aligned with the analysed background colour without restoring the render loop
- handle stale columns, CORS analysis failures, and transparent image pixels safely

## Verification

- `npm test -- --runInBand` (38 suites, 410 passed, 1 skipped)
- `npm run build`
- `npm run lint` (passes with pre-existing warnings only)
- adversarial review: Claude CLI and ultra subagent clean

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->