### PR TITLE
Harden PDF source loading against SSRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ NEXT_PUBLIC_PROJECT_SERVER_PERSISTENCE=false
 # RATE_LIMIT_API_PER_MIN=120
 # RATE_LIMIT_UPLOAD_PER_MIN=6
 # RATE_LIMIT_GENERATE_PER_MIN=10
+# RATE_LIMIT_DOWNLOAD_PER_MIN=30
 # RATE_LIMIT_ZIP_PER_MIN=5
 # RATE_LIMIT_EMAIL_PER_MIN=3
 
@@ -59,6 +60,12 @@ STORAGE_PROVIDER=local
 # S3_BUCKET_NAME=your-bucket-name
 # S3_REGION=us-east-1
 # S3_CLOUDFRONT_URL=https://d1234567890.cloudfront.net  # Optional CDN
+
+# Server-side PDF retrieval limits (downloads, ZIPs, and email attachments)
+# MAX_PDF_SOURCE_SIZE_BYTES=26214400  # 25MB per PDF
+# PDF_SOURCE_FETCH_TIMEOUT_MS=10000   # 10 seconds
+# MAX_BULK_EMAIL_ATTACHMENT_BYTES=104857600  # 100MB per bulk request (250MB hard max)
+# MAX_ZIP_DURATION_MS=60000  # Whole ZIP operation (120 seconds hard max)
 
 # ========================================
 # EMAIL CONFIGURATION (Optional)

--- a/__tests__/api/force-download.test.ts
+++ b/__tests__/api/force-download.test.ts
@@ -1,31 +1,69 @@
 import { createMocks } from 'node-mocks-http';
-import handler from '../../pages/api/force-download';
+import { requireAuth } from '@/lib/auth/requireAuth';
+import { enforceRateLimit } from '@/lib/rate-limit';
+import {
+  loadTrustedPdf,
+  PdfSourceError,
+} from '@/lib/security/trusted-pdf-source';
+import handler from '@/pages/api/force-download';
 
-// Mock environment variables
-const originalEnv = process.env;
-
-// Mock the R2 client
-jest.mock('../../lib/r2-client', () => ({
-  isR2Configured: jest.fn(),
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({
+  __esModule: true,
+  authOptions: {},
+  default: jest.fn(),
 }));
 
-// Mock fs module
-jest.mock('fs', () => ({
-  existsSync: jest.fn(),
-  readFileSync: jest.fn(),
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(),
 }));
 
-// Mock fetch for R2 requests
-global.fetch = jest.fn();
+jest.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: jest.fn(),
+}));
+
+jest.mock('@/lib/security/trusted-pdf-source', () => {
+  const actual = jest.requireActual('@/lib/security/trusted-pdf-source');
+  return { ...actual, loadTrustedPdf: jest.fn() };
+});
+
+const mockedRequireAuth = requireAuth as jest.MockedFunction<typeof requireAuth>;
+const mockedEnforceRateLimit = enforceRateLimit as jest.MockedFunction<typeof enforceRateLimit>;
+const mockedLoadTrustedPdf = loadTrustedPdf as jest.MockedFunction<typeof loadTrustedPdf>;
 
 describe('/api/force-download', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset process.env to a fresh object
-    process.env = { ...originalEnv };
+    mockedRequireAuth.mockResolvedValue({ user: { id: 'u1' } } as any);
+    mockedEnforceRateLimit.mockReturnValue({
+      allowed: true,
+      retryAfter: 0,
+      limit: 30,
+      remaining: 29,
+    });
   });
 
-  it('should reject non-string URL parameter', async () => {
+  it('rejects non-GET requests before authentication', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(mockedRequireAuth).not.toHaveBeenCalled();
+  });
+
+  it('does not load a source when authentication fails', async () => {
+    mockedRequireAuth.mockResolvedValue(null);
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: { url: 'https://certs.example.com/generated/a.pdf' },
+    });
+
+    await handler(req, res);
+
+    expect(mockedLoadTrustedPdf).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string URL parameter', async () => {
     const { req, res } = createMocks({
       method: 'GET',
       query: { url: 123 },
@@ -34,167 +72,88 @@ describe('/api/force-download', () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
-    expect(JSON.parse(res._getData())).toEqual({
-      error: 'URL parameter is required'
-    });
+    expect(JSON.parse(res._getData())).toEqual({ error: 'URL parameter is required' });
   });
 
-  it('should handle R2 custom domain URLs correctly', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    
-    // Set custom domain environment variable
-    process.env.R2_PUBLIC_URL = 'https://certs.tk.sg';
-    
-    // Mock successful fetch response
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(mockPdfBuffer.buffer),
+  it('rate-limits downloads before loading the source', async () => {
+    mockedEnforceRateLimit.mockReturnValue({
+      allowed: false,
+      retryAfter: 60,
+      limit: 30,
+      remaining: 0,
     });
-
     const { req, res } = createMocks({
       method: 'GET',
-      query: { 
-        url: 'https://certs.tk.sg/generated/individual_123/cert.pdf',
-        filename: 'custom_name.pdf'
+      query: { url: '/generated/a.pdf' },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(mockedLoadTrustedPdf).not.toHaveBeenCalled();
+  });
+
+  it('loads only through the trusted source loader and sanitizes the filename', async () => {
+    const pdf = Buffer.from('%PDF-1.4\ntrusted');
+    mockedLoadTrustedPdf.mockResolvedValue({ buffer: pdf, source: 'remote' });
+    const { req, res } = createMocks({
+      method: 'GET',
+      query: {
+        url: 'https://certs.example.com/generated/a.pdf',
+        filename: '../../custom\r\n".pdf',
       },
     });
 
     await handler(req, res);
 
-    expect(fetch).toHaveBeenCalledWith('https://certs.tk.sg/generated/individual_123/cert.pdf');
+    expect(mockedLoadTrustedPdf).toHaveBeenCalledWith(
+      'https://certs.example.com/generated/a.pdf'
+    );
     expect(res._getStatusCode()).toBe(200);
     expect(res.getHeader('Content-Type')).toBe('application/pdf');
-    expect(res.getHeader('Content-Disposition')).toBe('attachment; filename="custom_name.pdf"');
-    // Just verify that data was sent, not the exact content
-    expect(res._getData()).toBeDefined();
-    expect(res._getData().length).toBeGreaterThan(0);
+    expect(res.getHeader('Content-Disposition')).toBe(
+      'attachment; filename="custom___.pdf"'
+    );
+    expect(res.getHeader('Cache-Control')).toBe('private, no-store');
+    expect(res._getData()).toEqual(pdf);
   });
 
-  it('should handle direct R2 endpoint URLs correctly', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    
-    // Clear custom domain for this test
-    delete process.env.R2_PUBLIC_URL;
-    
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(mockPdfBuffer.buffer),
+  it('uses a safe default filename', async () => {
+    mockedLoadTrustedPdf.mockResolvedValue({
+      buffer: Buffer.from('%PDF-1.4\ntrusted'),
+      source: 'local',
     });
-
     const { req, res } = createMocks({
       method: 'GET',
-      query: { 
-        url: 'https://account.r2.cloudflarestorage.com/bucket/generated/cert.pdf',
-        filename: 'test.pdf'
-      },
+      query: { url: '/generated/a.pdf' },
     });
 
     await handler(req, res);
 
-    expect(fetch).toHaveBeenCalledWith('https://account.r2.cloudflarestorage.com/bucket/generated/cert.pdf');
-    expect(res._getStatusCode()).toBe(200);
+    expect(res.getHeader('Content-Disposition')).toBe(
+      'attachment; filename="download.pdf"'
+    );
   });
 
-  it('should handle R2 fetch errors gracefully', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    process.env.R2_PUBLIC_URL = 'https://certs.tk.sg';
-    
-    // Mock failed fetch response
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: false,
-      status: 404,
-    });
-
+  it('returns the trusted loader error without setting download headers', async () => {
+    mockedLoadTrustedPdf.mockRejectedValue(
+      new PdfSourceError(
+        'INVALID_SOURCE',
+        'PDF source is not an approved storage origin',
+        403
+      )
+    );
     const { req, res } = createMocks({
       method: 'GET',
-      query: { 
-        url: 'https://certs.tk.sg/generated/nonexistent.pdf',
-      },
+      query: { url: 'https://attacker.example/internal.pdf' },
     });
 
     await handler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
+    expect(res._getStatusCode()).toBe(403);
     expect(JSON.parse(res._getData())).toEqual({
-      error: 'File not found'
+      error: 'PDF source is not an approved storage origin',
     });
-  });
-
-  it('should handle local files when R2 is not configured', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    const fs = require('fs');
-    
-    isR2Configured.mockReturnValue(false);
-    fs.existsSync.mockReturnValue(true);
-    
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    fs.readFileSync.mockReturnValue(mockPdfBuffer);
-
-    const { req, res } = createMocks({
-      method: 'GET',
-      query: { 
-        url: '/generated/test.pdf',
-        filename: 'local_test.pdf'
-      },
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(200);
-    expect(res.getHeader('Content-Disposition')).toBe('attachment; filename="local_test.pdf"');
-    expect(res._getData()).toEqual(mockPdfBuffer);
-  });
-
-  it('should reject invalid local file paths for security', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(false);
-
-    const { req, res } = createMocks({
-      method: 'GET',
-      query: { 
-        url: '/generated/../../../etc/passwd',
-      },
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(400);
-    expect(JSON.parse(res._getData())).toEqual({
-      error: 'Invalid URL format'
-    });
-  });
-
-  it('should use default filename when not provided', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    process.env.R2_PUBLIC_URL = 'https://certs.tk.sg';
-    
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(mockPdfBuffer.buffer),
-    });
-
-    const { req, res } = createMocks({
-      method: 'GET',
-      query: { 
-        url: 'https://certs.tk.sg/generated/test.pdf',
-        // No filename provided
-      },
-    });
-
-    await handler(req, res);
-
-    expect(res.getHeader('Content-Disposition')).toBe('attachment; filename="download.pdf"');
-  });
-
-  afterEach(() => {
-    // Restore original environment
-    process.env = originalEnv;
+    expect(res.getHeader('Content-Disposition')).toBeUndefined();
   });
 });

--- a/__tests__/api/send-bulk-email-attachment-limits.test.ts
+++ b/__tests__/api/send-bulk-email-attachment-limits.test.ts
@@ -1,0 +1,133 @@
+import { createMocks } from 'node-mocks-http';
+import { getEmailProvider } from '@/lib/email/provider-factory';
+import { buildPdfAttachments } from '../../utils/email-utils';
+import handler from '@/pages/api/send-bulk-email';
+
+const mockAddToQueue = jest.fn();
+
+jest.mock('@/lib/email/email-queue', () => ({
+  EmailQueueManager: jest.fn(() => ({
+    addToQueue: mockAddToQueue,
+    isProcessing: jest.fn(() => true),
+    processQueue: jest.fn(),
+    getQueueLength: jest.fn(() => 0),
+    getStatus: jest.fn(() => ({ status: 'idle' })),
+    getLastActivity: jest.fn(() => Date.now()),
+  })),
+}));
+
+jest.mock('@/lib/email/provider-factory');
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({
+  __esModule: true,
+  authOptions: {},
+  default: jest.fn(),
+}));
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(async () => ({ user: { id: 'u1' } })),
+}));
+jest.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: jest.fn(() => ({ allowed: true })),
+}));
+jest.mock('../../utils/email-utils', () => {
+  const actual = jest.requireActual('../../utils/email-utils');
+  return { ...actual, buildPdfAttachments: jest.fn() };
+});
+
+const mockedGetEmailProvider = getEmailProvider as jest.MockedFunction<typeof getEmailProvider>;
+const mockedBuildPdfAttachments = buildPdfAttachments as jest.MockedFunction<typeof buildPdfAttachments>;
+const originalEnv = process.env;
+
+function email(index: number) {
+  return {
+    to: `recipient${index}@example.com`,
+    senderName: 'Sender',
+    subject: 'Certificate',
+    html: '<p>Attached</p>',
+    attachments: [{
+      path: `https://certs.example.com/generated/${index}.pdf`,
+      filename: `${index}.pdf`,
+    }],
+  };
+}
+
+function requestFor(emails: ReturnType<typeof email>[], sessionId: string) {
+  return createMocks({
+    method: 'POST',
+    body: {
+      emails,
+      config: { senderName: 'Sender', subject: 'Certificate', message: 'Attached' },
+      sessionId,
+    },
+  });
+}
+
+describe('/api/send-bulk-email attachment resource limits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    mockedGetEmailProvider.mockReturnValue({
+      name: 'resend',
+      sendEmail: jest.fn(),
+      getRateLimit: jest.fn(),
+      isConfigured: jest.fn(() => true),
+    } as any);
+    mockAddToQueue.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('limits attachment construction concurrency to four emails', async () => {
+    let active = 0;
+    let peak = 0;
+    mockedBuildPdfAttachments.mockImplementation(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      return [{
+        filename: 'certificate.pdf',
+        content: Buffer.from('%PDF-1.4\nsmall'),
+        contentType: 'application/pdf',
+      }];
+    });
+    const { req, res } = requestFor(
+      Array.from({ length: 8 }, (_, index) => email(index)),
+      'concurrency-test'
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockedBuildPdfAttachments).toHaveBeenCalledTimes(8);
+    expect(peak).toBe(4);
+  });
+
+  it('rejects a batch that exceeds the request-wide attachment budget', async () => {
+    process.env.MAX_BULK_EMAIL_ATTACHMENT_BYTES = '20';
+    mockedBuildPdfAttachments.mockResolvedValue([{
+      filename: 'certificate.pdf',
+      content: Buffer.from('%PDF-123456789'),
+      contentType: 'application/pdf',
+    }]);
+    const { req, res } = requestFor([email(1), email(2)], 'aggregate-test');
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(413);
+    expect(mockAddToQueue).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than 500 emails before loading attachments', async () => {
+    const { req, res } = requestFor(
+      Array.from({ length: 501 }, (_, index) => email(index)),
+      'count-test'
+    );
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(413);
+    expect(mockedBuildPdfAttachments).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/zip-pdfs-custom-domain.test.ts
+++ b/__tests__/api/zip-pdfs-custom-domain.test.ts
@@ -1,258 +1,126 @@
 import { createMocks } from 'node-mocks-http';
-jest.mock('@/pages/api/auth/[...nextauth]', () => ({ __esModule: true, authOptions: {}, default: jest.fn() }));
-jest.mock('@/lib/auth/requireAuth', () => ({ requireAuth: jest.fn(async () => ({ user: { id: 'u1' } })) }));
-import handler from '../../pages/api/zip-pdfs';
+import handler from '@/pages/api/zip-pdfs';
 
-// Mock environment variables
-const originalEnv = process.env;
-
-// Mock the R2 client
-jest.mock('../../lib/r2-client', () => ({
-  isR2Configured: jest.fn(),
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({
+  __esModule: true,
+  authOptions: {},
+  default: jest.fn(),
 }));
 
-// Mock archiver
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(async () => ({ user: { id: 'u1' } })),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  buildKey: jest.fn(() => 'zip:custom-domain'),
+  rateLimit: jest.fn(() => ({
+    allowed: true,
+    limit: 5,
+    remaining: 4,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
 const mockArchive = {
   pipe: jest.fn(),
   append: jest.fn(),
-  file: jest.fn(),
-  finalize: jest.fn().mockResolvedValue(undefined),
+  abort: jest.fn(),
+  finalize: jest.fn<Promise<void>, []>(() => Promise.resolve()),
   on: jest.fn(),
-  pointer: jest.fn().mockReturnValue(1024),
+  pointer: jest.fn(() => 1024),
 };
 
-jest.mock('archiver', () => {
-  return jest.fn(() => mockArchive);
-});
+jest.mock('archiver', () => jest.fn(() => mockArchive));
 
-// Mock fs module
-jest.mock('fs', () => ({
-  existsSync: jest.fn(),
-}));
+const originalEnv = process.env;
+const originalFetch = global.fetch;
 
-// Mock fetch for R2 requests
-global.fetch = jest.fn();
+function pdfResponse(pdf: Buffer): Response {
+  let consumed = false;
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => String(pdf.length) },
+    body: {
+      getReader: () => ({
+        read: jest.fn(async () => {
+          if (consumed) return { done: true, value: undefined };
+          consumed = true;
+          return { done: false, value: new Uint8Array(pdf) };
+        }),
+        cancel: jest.fn(async () => undefined),
+        releaseLock: jest.fn(),
+      }),
+    },
+  } as unknown as Response;
+}
 
-describe('/api/zip-pdfs custom domain handling', () => {
+describe('/api/zip-pdfs trusted remote storage integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset process.env to a fresh object
-    process.env = { ...originalEnv };
-    // Reset mock functions
-    Object.values(mockArchive).forEach(fn => {
-      if (typeof fn === 'function') {
-        fn.mockClear?.();
-      }
-    });
-  });
-
-  it('should recognize custom domain URLs as R2 URLs', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    
-    // Set custom domain environment variable
-    process.env.R2_PUBLIC_URL = 'https://certs.tk.sg';
-    
-    // Mock successful fetch responses
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(mockPdfBuffer.buffer),
-    });
-
-    const files = [
-      { url: 'https://certs.tk.sg/generated/individual_123/cert1.pdf', filename: 'John_Doe.pdf' },
-      { url: 'https://certs.tk.sg/generated/individual_123/cert2.pdf', filename: 'Jane_Smith.pdf' }
-    ];
-
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: { files },
-    });
-
-    await handler(req, res);
-
-    // Verify that fetch was called for each file (R2 path)
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenCalledWith('https://certs.tk.sg/generated/individual_123/cert1.pdf');
-    expect(fetch).toHaveBeenCalledWith('https://certs.tk.sg/generated/individual_123/cert2.pdf');
-    
-    // Verify files were added to archive
-    expect(mockArchive.append).toHaveBeenCalledTimes(2);
-    expect(mockArchive.append).toHaveBeenCalledWith(
-      Buffer.from(mockPdfBuffer.buffer), 
-      { name: 'John_Doe.pdf' }
-    );
-    expect(mockArchive.append).toHaveBeenCalledWith(
-      Buffer.from(mockPdfBuffer.buffer), 
-      { name: 'Jane_Smith.pdf' }
-    );
-    
-    expect(mockArchive.finalize).toHaveBeenCalled();
-    expect(res._getStatusCode()).toBe(200);
-  });
-
-  it('should handle direct R2 endpoint URLs correctly', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    
-    // Clear custom domain for this test
-    delete process.env.R2_PUBLIC_URL;
-    
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(mockPdfBuffer.buffer),
-    });
-
-    const files = [
-      { url: 'https://account.r2.cloudflarestorage.com/bucket/generated/cert.pdf', filename: 'test.pdf' }
-    ];
-
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: { files },
-    });
-
-    await handler(req, res);
-
-    expect(fetch).toHaveBeenCalledWith('https://account.r2.cloudflarestorage.com/bucket/generated/cert.pdf');
-    expect(mockArchive.append).toHaveBeenCalledWith(
-      Buffer.from(mockPdfBuffer.buffer), 
-      { name: 'test.pdf' }
-    );
-  });
-
-  it('should fall back to local files when URLs do not match R2 patterns', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    const fs = require('fs');
-    
-    isR2Configured.mockReturnValue(true);
-    delete process.env.R2_PUBLIC_URL;
-    
-    fs.existsSync.mockReturnValue(true);
-
-    const files = [
-      { url: '/generated/local_cert.pdf', filename: 'local_test.pdf' }
-    ];
-
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: { files },
-    });
-
-    await handler(req, res);
-
-    // Should NOT call fetch (not an R2 URL)
-    expect(fetch).not.toHaveBeenCalled();
-    
-    // Should call archive.file for local files
-    expect(mockArchive.file).toHaveBeenCalledWith(
-      expect.stringContaining('public/generated/local_cert.pdf'),
-      { name: 'local_test.pdf' }
-    );
-  });
-
-  it('should skip files that fail to fetch from R2', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    process.env.R2_PUBLIC_URL = 'https://certs.tk.sg';
-    
-    // Mock one successful and one failed fetch
-    (global.fetch as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(Buffer.from('%PDF-1.4 good').buffer),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      });
-
-    const files = [
-      { url: 'https://certs.tk.sg/generated/good.pdf', filename: 'good.pdf' },
-      { url: 'https://certs.tk.sg/generated/missing.pdf', filename: 'missing.pdf' }
-    ];
-
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: { files },
-    });
-
-    await handler(req, res);
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-    
-    // Only the successful file should be added to archive
-    expect(mockArchive.append).toHaveBeenCalledTimes(1);
-    expect(mockArchive.append).toHaveBeenCalledWith(
-      expect.any(Buffer), 
-      { name: 'good.pdf' }
-    );
-    
-    expect(res._getStatusCode()).toBe(200);
-  });
-
-  it('should handle mixed R2 custom domain and direct endpoint URLs', async () => {
-    const { isR2Configured } = require('../../lib/r2-client');
-    isR2Configured.mockReturnValue(true);
-    process.env.R2_PUBLIC_URL = 'https://certs.tk.sg';
-    
-    const mockPdfBuffer = Buffer.from('%PDF-1.4 mock pdf content');
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      arrayBuffer: () => Promise.resolve(mockPdfBuffer.buffer),
-    });
-
-    const files = [
-      { url: 'https://certs.tk.sg/generated/custom_domain.pdf', filename: 'custom.pdf' },
-      { url: 'https://account.r2.cloudflarestorage.com/bucket/direct.pdf', filename: 'direct.pdf' }
-    ];
-
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: { files },
-    });
-
-    await handler(req, res);
-
-    // Both should be recognized as R2 URLs and fetched
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenCalledWith('https://certs.tk.sg/generated/custom_domain.pdf');
-    expect(fetch).toHaveBeenCalledWith('https://account.r2.cloudflarestorage.com/bucket/direct.pdf');
-    
-    expect(mockArchive.append).toHaveBeenCalledTimes(2);
-  });
-
-  it('should reject non-POST requests', async () => {
-    const { req, res } = createMocks({
-      method: 'GET',
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(405);
-    expect(JSON.parse(res._getData())).toEqual({
-      error: 'Method not allowed'
-    });
-  });
-
-  it('should handle empty files array', async () => {
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: { files: [] },
-    });
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(400);
-    expect(JSON.parse(res._getData())).toEqual({
-      error: 'No files provided'
-    });
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      R2_ENDPOINT: 'https://account.r2.cloudflarestorage.com',
+      R2_PUBLIC_URL: 'https://certs.example.com',
+    };
+    global.fetch = jest.fn();
   });
 
   afterEach(() => {
-    // Restore original environment
     process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it('fetches an exact custom-domain URL and appends the validated PDF', async () => {
+    const pdf = Buffer.from('%PDF-1.4\ncustom domain');
+    (global.fetch as jest.Mock).mockResolvedValue(pdfResponse(pdf));
+    const url = 'https://certs.example.com/generated/a.pdf';
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { files: [{ url, filename: 'a.pdf' }] },
+    });
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({ redirect: 'error', signal: expect.anything() })
+    );
+    expect(mockArchive.append).toHaveBeenCalledWith(pdf, { name: 'a.pdf' });
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('supports signed URLs on the configured R2 endpoint', async () => {
+    const pdf = Buffer.from('%PDF-1.4\nsigned');
+    (global.fetch as jest.Mock).mockResolvedValue(pdfResponse(pdf));
+    const url = 'https://account.r2.cloudflarestorage.com/bucket/generated/a.pdf?X-Amz-Signature=test';
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { files: [{ url, filename: 'signed.pdf' }] },
+    });
+
+    await handler(req, res);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(mockArchive.append).toHaveBeenCalledWith(pdf, { name: 'signed.pdf' });
+  });
+
+  it('rejects hostname-prefix tricks without making a request', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        files: [{
+          url: 'https://certs.example.com.attacker.test/internal.pdf',
+          filename: 'bad.pdf',
+        }],
+      },
+    });
+
+    await handler(req, res);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockArchive.append).not.toHaveBeenCalled();
+    expect(mockArchive.finalize).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/api/zip-pdfs.test.ts
+++ b/__tests__/api/zip-pdfs.test.ts
@@ -1,98 +1,245 @@
 import { createMocks } from 'node-mocks-http';
-jest.mock('@/pages/api/auth/[...nextauth]', () => ({ __esModule: true, authOptions: {}, default: jest.fn() }));
-jest.mock('@/lib/auth/requireAuth', () => ({ requireAuth: jest.fn(async () => ({ user: { id: 'u1' } })) }));
+import { requireAuth } from '@/lib/auth/requireAuth';
+import {
+  loadTrustedPdf,
+  PdfSourceError,
+} from '@/lib/security/trusted-pdf-source';
 import handler from '@/pages/api/zip-pdfs';
-import fs from 'fs';
-import path from 'path';
 
-// Mock archiver
-jest.mock('archiver', () => {
-  const mockArchive = {
-    pipe: jest.fn(),
-    append: jest.fn(),
-    file: jest.fn(), // Add missing file method
-    finalize: jest.fn().mockResolvedValue(undefined),
-    on: jest.fn(),
-    pointer: jest.fn().mockReturnValue(1024), // Add pointer method for logging
-  };
-  return jest.fn(() => mockArchive);
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({
+  __esModule: true,
+  authOptions: {},
+  default: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(),
+}));
+
+jest.mock('@/lib/rate-limit', () => ({
+  buildKey: jest.fn(() => 'zip:test'),
+  rateLimit: jest.fn(() => ({
+    allowed: true,
+    limit: 5,
+    remaining: 4,
+    resetAt: Date.now() + 60_000,
+  })),
+}));
+
+jest.mock('@/lib/security/trusted-pdf-source', () => {
+  const actual = jest.requireActual('@/lib/security/trusted-pdf-source');
+  return { ...actual, loadTrustedPdf: jest.fn() };
 });
 
-// Mock fs
-jest.mock('fs');
+const mockArchive = {
+  pipe: jest.fn(),
+  append: jest.fn(),
+  abort: jest.fn(),
+  finalize: jest.fn<Promise<void>, []>(),
+  on: jest.fn(),
+  pointer: jest.fn(() => 1024),
+};
+
+jest.mock('archiver', () => jest.fn(() => mockArchive));
+
+const mockedRequireAuth = requireAuth as jest.MockedFunction<typeof requireAuth>;
+const mockedLoadTrustedPdf = loadTrustedPdf as jest.MockedFunction<typeof loadTrustedPdf>;
+const originalEnv = process.env;
 
 describe('/api/zip-pdfs', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    mockedRequireAuth.mockResolvedValue({ user: { id: 'u1' } } as any);
+    mockArchive.finalize.mockResolvedValue(undefined);
   });
 
-  it('should return 405 for non-POST requests', async () => {
-    const { req, res } = createMocks({
-      method: 'GET',
-    });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(405);
-    expect(JSON.parse(res._getData())).toEqual({ error: 'Method not allowed' });
+    expect(mockedRequireAuth).not.toHaveBeenCalled();
   });
 
-  it('should return 400 if no files provided', async () => {
-    const { req, res } = createMocks({
-      method: 'POST',
-      body: {},
-    });
+  it('validates the file list before authentication', async () => {
+    const { req, res } = createMocks({ method: 'POST', body: {} });
 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(400);
     expect(JSON.parse(res._getData())).toEqual({ error: 'No files provided' });
+    expect(mockedRequireAuth).not.toHaveBeenCalled();
   });
 
-  it('should create a ZIP file with provided PDFs', async () => {
-    const mockFiles = [
-      { url: '/api/files/generated/individual_123/test1.pdf', filename: 'Certificate1.pdf' },
-      { url: '/api/files/generated/individual_123/test2.pdf', filename: 'Certificate2.pdf' },
-    ];
+  it('rejects oversized and malformed file lists', async () => {
+    const tooMany = Array.from({ length: 501 }, (_, index) => ({
+      url: `/generated/${index}.pdf`,
+      filename: `${index}.pdf`,
+    }));
+    const first = createMocks({ method: 'POST', body: { files: tooMany } });
+    await handler(first.req, first.res);
+    expect(first.res._getStatusCode()).toBe(413);
 
-    // Mock fs.existsSync to return true
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
-    
-    // Mock fs.createReadStream
-    (fs.createReadStream as jest.Mock).mockReturnValue({
-      pipe: jest.fn(),
-      on: jest.fn(),
+    const second = createMocks({
+      method: 'POST',
+      body: { files: [{ url: '/generated/a.pdf' }] },
     });
+    await handler(second.req, second.res);
+    expect(second.res._getStatusCode()).toBe(400);
+    expect(mockedLoadTrustedPdf).not.toHaveBeenCalled();
+  });
 
+  it('does not load sources when authentication fails', async () => {
+    mockedRequireAuth.mockResolvedValue(null);
     const { req, res } = createMocks({
       method: 'POST',
-      body: { files: mockFiles },
+      body: { files: [{ url: '/generated/a.pdf', filename: 'a.pdf' }] },
     });
 
     await handler(req, res);
 
-    expect(res._getHeaders()['content-type']).toBe('application/zip');
-    expect(res._getHeaders()['content-disposition']).toBe('attachment; filename="certificates.zip"');
+    expect(mockedLoadTrustedPdf).not.toHaveBeenCalled();
   });
 
-  it('should handle direct URLs from public folder', async () => {
-    const mockFiles = [
-      { url: '/generated/individual_456/test1.pdf', filename: 'Certificate1.pdf' },
-      { url: '/generated/individual_456/test2.pdf', filename: 'Certificate2.pdf' },
+  it('loads every PDF through the trusted loader and sanitizes ZIP entry names', async () => {
+    const firstPdf = Buffer.from('%PDF-1.4\nfirst');
+    const secondPdf = Buffer.from('%PDF-1.4\nsecond');
+    mockedLoadTrustedPdf
+      .mockResolvedValueOnce({ buffer: firstPdf, source: 'local' })
+      .mockResolvedValueOnce({ buffer: secondPdf, source: 'remote' });
+    const files = [
+      { url: '/generated/one.pdf', filename: '../../one\r\n.pdf' },
+      { url: 'https://certs.example.com/generated/two.pdf', filename: 'two.pdf' },
     ];
+    const { req, res } = createMocks({ method: 'POST', body: { files } });
 
-    // Mock file existence
-    (fs.existsSync as jest.Mock).mockReturnValue(true);
-    (fs.createReadStream as jest.Mock).mockReturnValue('mock-stream');
+    await handler(req, res);
 
+    expect(mockedLoadTrustedPdf).toHaveBeenCalledTimes(2);
+    expect(mockedLoadTrustedPdf).toHaveBeenNthCalledWith(
+      1,
+      '/generated/one.pdf',
+      expect.any(Number),
+      expect.objectContaining({ timeoutMs: expect.any(Number) })
+    );
+    expect(mockArchive.append).toHaveBeenNthCalledWith(
+      1,
+      firstPdf,
+      { name: 'one__.pdf' }
+    );
+    expect(mockArchive.append).toHaveBeenNthCalledWith(
+      2,
+      secondPdf,
+      { name: 'two.pdf' }
+    );
+    expect(mockArchive.finalize).toHaveBeenCalledTimes(1);
+    expect(res._getHeaders()['content-type']).toBe('application/zip');
+    expect(res._getHeaders()['cache-control']).toBe('private, no-store');
+  });
+
+  it('skips rejected sources without adding them to the archive', async () => {
+    mockedLoadTrustedPdf
+      .mockRejectedValueOnce(new PdfSourceError('INVALID_SOURCE', 'Rejected', 403))
+      .mockResolvedValueOnce({
+        buffer: Buffer.from('%PDF-1.4\ngood'),
+        source: 'local',
+      });
     const { req, res } = createMocks({
       method: 'POST',
-      body: { files: mockFiles },
+      body: {
+        files: [
+          { url: 'https://attacker.example/a.pdf', filename: 'bad.pdf' },
+          { url: '/generated/good.pdf', filename: 'good.pdf' },
+        ],
+      },
     });
 
     await handler(req, res);
 
-    expect(res._getHeaders()['content-type']).toBe('application/zip');
-    expect(res._getHeaders()['content-disposition']).toBe('attachment; filename="certificates.zip"');
+    expect(mockedLoadTrustedPdf).toHaveBeenCalledTimes(2);
+    expect(mockArchive.append).toHaveBeenCalledTimes(1);
+    expect(mockArchive.finalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops after a too-large source to bound rejected input reads', async () => {
+    mockedLoadTrustedPdf.mockRejectedValue(
+      new PdfSourceError('PDF_TOO_LARGE', 'Too large', 413)
+    );
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        files: [
+          { url: '/generated/large.pdf', filename: 'large.pdf' },
+          { url: '/generated/never-read.pdf', filename: 'other.pdf' },
+        ],
+      },
+    });
+
+    await handler(req, res);
+
+    expect(mockedLoadTrustedPdf).toHaveBeenCalledTimes(1);
+    expect(mockArchive.finalize).toHaveBeenCalledTimes(1);
+  });
+
+  it('turns asynchronous archive errors into a handled 500 response', async () => {
+    mockedLoadTrustedPdf.mockResolvedValue({
+      buffer: Buffer.from('%PDF-1.4\ngood'),
+      source: 'local',
+    });
+    mockArchive.finalize.mockImplementationOnce(async () => {
+      const errorHandler = mockArchive.on.mock.calls.find(([event]) => event === 'error')?.[1];
+      errorHandler?.(new Error('archive failed'));
+    });
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { files: [{ url: '/generated/a.pdf', filename: 'a.pdf' }] },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(JSON.parse(res._getData())).toEqual({ error: 'Failed to create ZIP file' });
+  });
+
+  it('handles an archive error emitted during an awaited source load', async () => {
+    mockedLoadTrustedPdf.mockImplementationOnce(async () => {
+      const errorHandler = mockArchive.on.mock.calls.find(([event]) => event === 'error')?.[1];
+      errorHandler?.(new Error('early archive failure'));
+      return { buffer: Buffer.from('%PDF-1.4\ngood'), source: 'local' };
+    });
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { files: [{ url: '/generated/a.pdf', filename: 'a.pdf' }] },
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(mockArchive.append).not.toHaveBeenCalled();
+    expect(mockArchive.finalize).not.toHaveBeenCalled();
+  });
+
+  it('aborts work that exceeds the whole ZIP deadline', async () => {
+    process.env.MAX_ZIP_DURATION_MS = '5';
+    mockedLoadTrustedPdf.mockImplementationOnce(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return { buffer: Buffer.from('%PDF-1.4\nlate'), source: 'remote' };
+    });
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { files: [{ url: '/generated/a.pdf', filename: 'a.pdf' }] },
+    });
+
+    await handler(req, res);
+
+    expect(mockArchive.abort).toHaveBeenCalledTimes(1);
+    expect(mockArchive.append).not.toHaveBeenCalled();
+    expect(res._getStatusCode()).toBe(500);
   });
 });

--- a/__tests__/lib/email-utils-security.test.ts
+++ b/__tests__/lib/email-utils-security.test.ts
@@ -1,0 +1,111 @@
+import { buildPdfAttachments } from '@/utils/email-utils';
+import {
+  loadTrustedPdf,
+  PdfSourceError,
+} from '@/lib/security/trusted-pdf-source';
+
+jest.mock('@/lib/security/trusted-pdf-source', () => {
+  const actual = jest.requireActual('@/lib/security/trusted-pdf-source');
+  return { ...actual, loadTrustedPdf: jest.fn() };
+});
+
+const mockedLoadTrustedPdf = loadTrustedPdf as jest.MockedFunction<typeof loadTrustedPdf>;
+
+describe('email PDF attachment security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads URL attachments only through the trusted loader', async () => {
+    const pdf = Buffer.from('%PDF-1.4\ntrusted');
+    mockedLoadTrustedPdf.mockResolvedValue({ buffer: pdf, source: 'remote' });
+
+    await expect(buildPdfAttachments({
+      attachmentUrl: 'https://certs.example.com/generated/a.pdf',
+      defaultFilename: '../../certificate\r\n.pdf',
+      maxTotalBytes: 1024,
+    })).resolves.toEqual([{
+      filename: 'certificate__.pdf',
+      content: pdf,
+      contentType: 'application/pdf',
+    }]);
+    expect(mockedLoadTrustedPdf).toHaveBeenCalledWith(
+      'https://certs.example.com/generated/a.pdf',
+      1024
+    );
+  });
+
+  it('propagates rejected sources instead of sending an attachment-free email', async () => {
+    mockedLoadTrustedPdf.mockRejectedValue(
+      new PdfSourceError('INVALID_SOURCE', 'Unapproved source', 403)
+    );
+
+    await expect(buildPdfAttachments({
+      attachmentUrl: 'https://attacker.example/internal.pdf',
+    })).rejects.toMatchObject({ code: 'INVALID_SOURCE', statusCode: 403 });
+  });
+
+  it('enforces a combined byte limit across attachment arrays', async () => {
+    const first = Buffer.from('%PDF-123456789');
+    const second = Buffer.from('%PDF-abcdefghi');
+    mockedLoadTrustedPdf
+      .mockResolvedValueOnce({ buffer: first, source: 'remote' })
+      .mockResolvedValueOnce({ buffer: second, source: 'remote' });
+
+    await expect(buildPdfAttachments({
+      attachments: [
+        { path: 'https://certs.example.com/first.pdf', filename: 'first.pdf' },
+        { path: 'https://certs.example.com/second.pdf', filename: 'second.pdf' },
+      ],
+      maxTotalBytes: 20,
+    })).rejects.toMatchObject({ code: 'PDF_TOO_LARGE', statusCode: 413 });
+    expect(mockedLoadTrustedPdf).toHaveBeenNthCalledWith(
+      2,
+      'https://certs.example.com/second.pdf',
+      6
+    );
+  });
+
+  it('caps attachment count before loading any URL', async () => {
+    const attachments = Array.from({ length: 11 }, (_, index) => ({
+      path: `https://certs.example.com/${index}.pdf`,
+      filename: `${index}.pdf`,
+    }));
+
+    await expect(buildPdfAttachments({ attachments }))
+      .rejects.toMatchObject({ code: 'PDF_TOO_LARGE', statusCode: 413 });
+    expect(mockedLoadTrustedPdf).not.toHaveBeenCalled();
+  });
+
+  it('rejects inline attachment data that is not a PDF', async () => {
+    await expect(buildPdfAttachments({
+      attachmentData: Buffer.from('<html>not a pdf</html>').toString('base64'),
+    })).rejects.toMatchObject({ code: 'INVALID_PDF', statusCode: 415 });
+  });
+
+  it('rejects oversized base64 before accepting decoded attachment data', async () => {
+    await expect(buildPdfAttachments({
+      attachmentData: 'A'.repeat(100),
+      maxTotalBytes: 8,
+    })).rejects.toMatchObject({ code: 'PDF_TOO_LARGE', statusCode: 413 });
+  });
+
+  it('rejects invalid values in serialized byte arrays', async () => {
+    await expect(buildPdfAttachments({
+      attachmentData: [37, 80, 68, 70, 45, 256],
+    })).rejects.toMatchObject({ code: 'INVALID_PDF', statusCode: 400 });
+  });
+
+  it('rejects Buffer-shaped JSON objects before allocating their data', async () => {
+    await expect(buildPdfAttachments({
+      attachments: [{
+        filename: 'certificate.pdf',
+        content: {
+          type: 'Buffer',
+          data: Array.from({ length: 100 }, () => 65),
+        } as unknown as Buffer,
+      }],
+      maxTotalBytes: 8,
+    })).rejects.toMatchObject({ code: 'INVALID_PDF', statusCode: 400 });
+  });
+});

--- a/__tests__/lib/ses-provider-security.test.ts
+++ b/__tests__/lib/ses-provider-security.test.ts
@@ -1,0 +1,131 @@
+import { SESProvider } from '@/lib/email/providers/ses';
+import {
+  loadTrustedPdf,
+  PdfSourceError,
+} from '@/lib/security/trusted-pdf-source';
+
+const mockSesSend = jest.fn();
+const mockRawCommand = jest.fn((input) => ({ input }));
+
+jest.mock('@aws-sdk/client-ses', () => ({
+  SESClient: jest.fn(() => ({ send: mockSesSend })),
+  SendEmailCommand: jest.fn((input) => ({ input })),
+  SendRawEmailCommand: jest.fn((input) => mockRawCommand(input)),
+}));
+
+jest.mock('@/lib/security/trusted-pdf-source', () => {
+  const actual = jest.requireActual('@/lib/security/trusted-pdf-source');
+  return { ...actual, loadTrustedPdf: jest.fn() };
+});
+
+const mockedLoadTrustedPdf = loadTrustedPdf as jest.MockedFunction<typeof loadTrustedPdf>;
+const originalEnv = process.env;
+
+describe('SES attachment source security', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      AWS_ACCESS_KEY_ID: 'test-key',
+      AWS_SECRET_ACCESS_KEY: 'test-secret',
+      AWS_SES_REGION: 'ap-southeast-1',
+    };
+    mockSesSend.mockResolvedValue({ MessageId: 'message-1' });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('routes a direct provider path through the trusted PDF loader', async () => {
+    const pdf = Buffer.from('%PDF-1.4\ntrusted');
+    mockedLoadTrustedPdf.mockResolvedValue({ buffer: pdf, source: 'remote' });
+    const provider = new SESProvider();
+
+    const result = await provider.sendEmail({
+      to: ['recipient@example.com'],
+      from: 'sender@example.com',
+      subject: 'Certificate',
+      html: '<p>Attached</p>',
+      attachments: [{
+        path: 'https://certs.example.com/generated/a.pdf',
+        filename: '../../unsafe\r\n.pdf',
+        contentType: 'application/pdf',
+      }],
+    });
+
+    expect(mockedLoadTrustedPdf).toHaveBeenCalledWith(
+      'https://certs.example.com/generated/a.pdf'
+    );
+    expect(mockRawCommand).toHaveBeenCalledTimes(1);
+    const rawData = mockRawCommand.mock.calls[0][0].RawMessage.Data as Buffer;
+    expect(rawData.toString()).toContain('filename="unsafe__.pdf"');
+    expect(result.success).toBe(true);
+  });
+
+  it('fails closed when the provider receives an unapproved path', async () => {
+    mockedLoadTrustedPdf.mockRejectedValue(
+      new PdfSourceError('INVALID_SOURCE', 'Unapproved source', 403)
+    );
+    const provider = new SESProvider();
+
+    const result = await provider.sendEmail({
+      to: ['recipient@example.com'],
+      from: 'sender@example.com',
+      subject: 'Certificate',
+      html: '<p>Attached</p>',
+      attachments: [{
+        path: 'https://attacker.example/internal.pdf',
+        filename: 'certificate.pdf',
+      }],
+    });
+
+    expect(result).toMatchObject({ success: false, error: 'Unapproved source' });
+    expect(mockSesSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects CRLF injection in raw MIME headers', async () => {
+    const provider = new SESProvider();
+
+    const result = await provider.sendEmail({
+      to: ['recipient@example.com'],
+      from: 'sender@example.com',
+      subject: 'Certificate\r\nBcc: attacker@example.com',
+      html: '<p>Attached</p>',
+      attachments: [{
+        content: Buffer.from('%PDF-1.4\ntrusted'),
+        filename: 'certificate.pdf',
+      }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Invalid Subject email header',
+    });
+    expect(mockSesSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects Buffer-shaped plain objects passed directly to the provider', async () => {
+    const provider = new SESProvider();
+
+    const result = await provider.sendEmail({
+      to: ['recipient@example.com'],
+      from: 'sender@example.com',
+      subject: 'Certificate',
+      html: '<p>Attached</p>',
+      attachments: [{
+        content: {
+          type: 'Buffer',
+          data: Array.from({ length: 100 }, () => 65),
+        } as unknown as Buffer,
+        filename: 'certificate.pdf',
+      }],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'Invalid PDF attachment content',
+    });
+    expect(mockSesSend).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/trusted-pdf-source.test.ts
+++ b/__tests__/lib/trusted-pdf-source.test.ts
@@ -1,0 +1,185 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  loadTrustedPdf,
+  PdfSourceError,
+  resolveManagedLocalPdfPath,
+  sanitizePdfFilename,
+  validateTrustedRemotePdfUrl,
+} from '@/lib/security/trusted-pdf-source';
+import { getGeneratedDir } from '@/lib/paths';
+
+const originalEnv = process.env;
+const originalFetch = global.fetch;
+
+function mockResponse(
+  body: Buffer,
+  options: { status?: number; contentLength?: string } = {}
+): Response {
+  const status = options.status ?? 200;
+  let consumed = false;
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => name.toLowerCase() === 'content-length'
+        ? options.contentLength ?? null
+        : null,
+    },
+    body: {
+      getReader: () => ({
+        read: jest.fn(async () => {
+          if (consumed) return { done: true, value: undefined };
+          consumed = true;
+          return { done: false, value: new Uint8Array(body) };
+        }),
+        cancel: jest.fn(async () => undefined),
+        releaseLock: jest.fn(),
+      }),
+    },
+  } as unknown as Response;
+}
+
+describe('trusted PDF source loading', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'test',
+      R2_ENDPOINT: 'https://account.r2.cloudflarestorage.com',
+      R2_PUBLIC_URL: 'https://certs.example.com',
+      S3_BUCKET_NAME: 'certificate-bucket',
+      S3_REGION: 'ap-southeast-1',
+    };
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it('allows only the exact configured storage origin', () => {
+    expect(validateTrustedRemotePdfUrl('https://certs.example.com/generated/a.pdf').origin)
+      .toBe('https://certs.example.com');
+
+    expect(() => validateTrustedRemotePdfUrl('https://certs.example.com.attacker.test/a.pdf'))
+      .toThrow(PdfSourceError);
+    expect(() => validateTrustedRemotePdfUrl('https://127.0.0.1/a.pdf?x=.r2.cloudflarestorage.com'))
+      .toThrow(PdfSourceError);
+  });
+
+  it('honors a configured storage path prefix', () => {
+    process.env.R2_PUBLIC_URL = 'https://certs.example.com/private-certs';
+
+    expect(validateTrustedRemotePdfUrl(
+      'https://certs.example.com/private-certs/generated/a.pdf'
+    ).pathname).toBe('/private-certs/generated/a.pdf');
+    expect(() => validateTrustedRemotePdfUrl(
+      'https://certs.example.com/private-certs-attacker/a.pdf'
+    )).toThrow(PdfSourceError);
+  });
+
+  it('rejects URL userinfo tricks before making a request', async () => {
+    await expect(loadTrustedPdf(
+      'https://account.r2.cloudflarestorage.com@127.0.0.1/internal.pdf'
+    )).rejects.toMatchObject({ code: 'INVALID_SOURCE' });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches an approved URL without following redirects', async () => {
+    const pdf = Buffer.from('%PDF-1.4\ntrusted');
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(pdf));
+
+    await expect(loadTrustedPdf('https://certs.example.com/generated/a.pdf'))
+      .resolves.toMatchObject({ buffer: pdf, source: 'remote' });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://certs.example.com/generated/a.pdf',
+      expect.objectContaining({ redirect: 'error', signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('rejects a declared response that exceeds the byte limit', async () => {
+    const pdf = Buffer.from('%PDF-1.4\nlarge');
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(pdf, { contentLength: '1000' }));
+
+    await expect(loadTrustedPdf('https://certs.example.com/generated/a.pdf', 32))
+      .rejects.toMatchObject({ code: 'PDF_TOO_LARGE', statusCode: 413 });
+  });
+
+  it('enforces the byte limit even without Content-Length', async () => {
+    const pdf = Buffer.from('%PDF-1.4\nthis response is too large');
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(pdf));
+
+    await expect(loadTrustedPdf('https://certs.example.com/generated/a.pdf', 12))
+      .rejects.toMatchObject({ code: 'PDF_TOO_LARGE', statusCode: 413 });
+  });
+
+  it('does not let a caller raise the configured byte ceiling', async () => {
+    process.env.MAX_PDF_SOURCE_SIZE_BYTES = '12';
+    const pdf = Buffer.from('%PDF-1.4\nthis response is too large');
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(pdf));
+
+    await expect(loadTrustedPdf(
+      'https://certs.example.com/generated/a.pdf',
+      1024
+    )).rejects.toMatchObject({ code: 'PDF_TOO_LARGE', statusCode: 413 });
+  });
+
+  it('rejects non-PDF content from an approved origin', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue(mockResponse(Buffer.from('<html>not a pdf</html>')));
+
+    await expect(loadTrustedPdf('https://certs.example.com/generated/a.pdf'))
+      .rejects.toMatchObject({ code: 'INVALID_PDF', statusCode: 415 });
+  });
+
+  it('confines local sources to generated PDF paths', () => {
+    expect(resolveManagedLocalPdfPath('/generated/session/cert.pdf'))
+      .toContain('public/generated/session/cert.pdf');
+    expect(() => resolveManagedLocalPdfPath('/generated/../../package.pdf'))
+      .toThrow(PdfSourceError);
+    expect(() => resolveManagedLocalPdfPath('/api/files/temp_images/u_1/cert.pdf'))
+      .toThrow(PdfSourceError);
+  });
+
+  it('rejects local symlinks that resolve outside generated storage', async () => {
+    const generatedDir = path.resolve(getGeneratedDir());
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const readFile = jest.spyOn(fs, 'readFileSync');
+    jest.spyOn(fs, 'realpathSync').mockImplementation(((value: fs.PathLike) => {
+      return path.resolve(String(value)) === generatedDir
+        ? generatedDir
+        : '/private/outside.pdf';
+    }) as typeof fs.realpathSync);
+
+    await expect(loadTrustedPdf('/generated/link.pdf'))
+      .rejects.toMatchObject({ code: 'INVALID_SOURCE', statusCode: 403 });
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('reads a real local PDF only after confinement and size checks', async () => {
+    const generatedDir = path.resolve(getGeneratedDir());
+    const filePath = path.join(generatedDir, 'session', 'certificate.pdf');
+    const pdf = Buffer.from('%PDF-1.4\nlocal');
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'realpathSync').mockImplementation(((value: fs.PathLike) => {
+      return path.resolve(String(value)) === generatedDir ? generatedDir : filePath;
+    }) as typeof fs.realpathSync);
+    jest.spyOn(fs, 'statSync').mockReturnValue({
+      isFile: () => true,
+      size: pdf.length,
+    } as fs.Stats);
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(pdf);
+
+    await expect(loadTrustedPdf('/generated/session/certificate.pdf'))
+      .resolves.toEqual({ buffer: pdf, source: 'local' });
+  });
+
+  it('sanitizes download and archive filenames', () => {
+    expect(sanitizePdfFilename('../../evil\r\nname".pdf')).toBe('evil__name_.pdf');
+    expect(sanitizePdfFilename('certificate')).toBe('certificate.pdf');
+    expect(sanitizePdfFilename(`${'a'.repeat(300)}.pdf`)).toMatch(/^a{176}\.pdf$/);
+  });
+});

--- a/lib/email/providers/ses.ts
+++ b/lib/email/providers/ses.ts
@@ -1,6 +1,18 @@
 import { SESClient, SendEmailCommand, SendRawEmailCommand } from '@aws-sdk/client-ses';
 import type { EmailParams, EmailResult, RateLimitInfo, EmailProvider } from '../types';
-import { promises as fs } from 'fs';
+import {
+  assertPdfBuffer,
+  getMaxPdfSourceBytes,
+  loadTrustedPdf,
+  PdfSourceError,
+  sanitizePdfFilename,
+} from '@/lib/security/trusted-pdf-source';
+
+function assertSafeMimeHeader(value: string, field: string): void {
+  if (/[\r\n]/.test(value)) {
+    throw new Error(`Invalid ${field} email header`);
+  }
+}
 
 export class SESProvider implements EmailProvider {
   name = 'ses' as const;
@@ -135,6 +147,10 @@ export class SESProvider implements EmailProvider {
    * Build raw MIME email message with attachments
    */
   private async buildRawEmailMessage(params: EmailParams): Promise<string> {
+    assertSafeMimeHeader(params.from, 'From');
+    assertSafeMimeHeader(params.subject, 'Subject');
+    params.to.forEach((recipient) => assertSafeMimeHeader(recipient, 'To'));
+
     const boundary = `----=_Part_${Date.now()}_${Math.random().toString(36).substring(2)}`;
     const altBoundary = `----=_Alt_${Date.now()}_${Math.random().toString(36).substring(2)}`;
 
@@ -173,35 +189,36 @@ export class SESProvider implements EmailProvider {
 
         // Get attachment content
         if (attachment.content) {
+          if (typeof attachment.content !== 'string' && !Buffer.isBuffer(attachment.content)) {
+            throw new PdfSourceError('INVALID_PDF', 'Invalid PDF attachment content', 400);
+          }
+          if (attachment.content.length > getMaxPdfSourceBytes()) {
+            throw new PdfSourceError('PDF_TOO_LARGE', 'PDF attachment exceeds the size limit', 413);
+          }
           attachmentData = Buffer.isBuffer(attachment.content) 
             ? attachment.content 
             : Buffer.from(attachment.content);
         } else if (attachment.path) {
-          // Handle file path - fetch content
-          try {
-            if (attachment.path.startsWith('http')) {
-              // URL - fetch from web
-              const response = await fetch(attachment.path);
-              const arrayBuffer = await response.arrayBuffer();
-              attachmentData = Buffer.from(arrayBuffer);
-            } else {
-              // Local file path
-              attachmentData = await fs.readFile(attachment.path);
-            }
-          } catch (error) {
-            console.error(`Failed to read attachment ${attachment.filename}:`, error);
-            continue; // Skip this attachment
-          }
+          // Keep the provider safe even if a future caller bypasses the API
+          // attachment builder and supplies a path directly.
+          const loaded = await loadTrustedPdf(attachment.path);
+          attachmentData = loaded.buffer;
         } else {
           console.warn(`Attachment ${attachment.filename} has no content or path`);
           continue;
         }
 
+        if (attachmentData.length > getMaxPdfSourceBytes()) {
+          throw new PdfSourceError('PDF_TOO_LARGE', 'PDF attachment exceeds the size limit', 413);
+        }
+        assertPdfBuffer(attachmentData);
+        const filename = sanitizePdfFilename(attachment.filename, 'certificate.pdf');
+
         // Add attachment to message
         message += `--${boundary}\r\n`;
-        message += `Content-Type: ${attachment.contentType || 'application/octet-stream'}; name="${attachment.filename}"\r\n`;
+        message += `Content-Type: application/pdf; name="${filename}"\r\n`;
         message += `Content-Transfer-Encoding: base64\r\n`;
-        message += `Content-Disposition: attachment; filename="${attachment.filename}"\r\n\r\n`;
+        message += `Content-Disposition: attachment; filename="${filename}"\r\n\r\n`;
         
         // Encode attachment as base64 with line breaks
         const base64Data = attachmentData.toString('base64');

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -37,6 +37,7 @@ export type LimitCategory =
   | 'api'
   | 'upload'
   | 'generate'
+  | 'download'
   | 'zip'
   | 'email';
 
@@ -44,6 +45,7 @@ const DEFAULTS: Record<LimitCategory, number> = {
   api: parseInt(process.env.RATE_LIMIT_API_PER_MIN || '120', 10),
   upload: parseInt(process.env.RATE_LIMIT_UPLOAD_PER_MIN || '6', 10),
   generate: parseInt(process.env.RATE_LIMIT_GENERATE_PER_MIN || '10', 10),
+  download: parseInt(process.env.RATE_LIMIT_DOWNLOAD_PER_MIN || '30', 10),
   zip: parseInt(process.env.RATE_LIMIT_ZIP_PER_MIN || '5', 10),
   email: parseInt(process.env.RATE_LIMIT_EMAIL_PER_MIN || '60', 10),
 };
@@ -117,4 +119,3 @@ export function enforceRateLimit(
     remaining: rl.remaining
   };
 }
-

--- a/lib/security/trusted-pdf-source.ts
+++ b/lib/security/trusted-pdf-source.ts
@@ -1,0 +1,337 @@
+import fs from 'fs';
+import path from 'path';
+import { getGeneratedDir } from '@/lib/paths';
+
+const DEFAULT_MAX_PDF_BYTES = 25 * 1024 * 1024;
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+const MAX_SOURCE_LENGTH = 8_192;
+const PDF_HEADER = Buffer.from('%PDF-');
+
+export type PdfSourceErrorCode =
+  | 'INVALID_SOURCE'
+  | 'NOT_FOUND'
+  | 'FETCH_FAILED'
+  | 'PDF_TOO_LARGE'
+  | 'INVALID_PDF';
+
+export class PdfSourceError extends Error {
+  constructor(
+    public readonly code: PdfSourceErrorCode,
+    message: string,
+    public readonly statusCode: number
+  ) {
+    super(message);
+    this.name = 'PdfSourceError';
+  }
+}
+
+export interface TrustedPdf {
+  buffer: Buffer;
+  source: 'local' | 'remote';
+}
+
+export interface LoadTrustedPdfOptions {
+  /** Optional smaller timeout for callers with an overall operation deadline. */
+  timeoutMs?: number;
+}
+
+function positiveInteger(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getMaxPdfSourceBytes(): number {
+  return positiveInteger(process.env.MAX_PDF_SOURCE_SIZE_BYTES, DEFAULT_MAX_PDF_BYTES);
+}
+
+function getFetchTimeoutMs(): number {
+  return positiveInteger(process.env.PDF_SOURCE_FETCH_TIMEOUT_MS, DEFAULT_FETCH_TIMEOUT_MS);
+}
+
+interface StorageBase {
+  origin: string;
+  pathPrefix: string;
+}
+
+function configuredStorageBases(): StorageBase[] {
+  const bases = new Map<string, StorageBase>();
+
+  const addConfiguredBase = (value: string | undefined) => {
+    if (!value) return;
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol === 'https:' || (parsed.protocol === 'http:' && process.env.NODE_ENV !== 'production')) {
+        const pathPrefix = parsed.pathname === '/'
+          ? '/'
+          : `${parsed.pathname.replace(/\/+$/, '')}/`;
+        bases.set(`${parsed.origin}${pathPrefix}`, { origin: parsed.origin, pathPrefix });
+      }
+    } catch {
+      // Invalid server configuration is ignored and therefore fails closed.
+    }
+  };
+
+  addConfiguredBase(process.env.R2_ENDPOINT);
+  addConfiguredBase(process.env.R2_PUBLIC_URL);
+  addConfiguredBase(process.env.S3_CLOUDFRONT_URL);
+
+  const bucket = process.env.S3_BUCKET_NAME;
+  if (bucket) {
+    const region = process.env.S3_REGION || 'us-east-1';
+    addConfiguredBase(`https://${bucket}.s3.${region}.amazonaws.com`);
+    addConfiguredBase(`https://${bucket}.s3.amazonaws.com`);
+  }
+
+  return [...bases.values()];
+}
+
+export function validateTrustedRemotePdfUrl(value: string): URL {
+  if (value.length > MAX_SOURCE_LENGTH) {
+    throw new PdfSourceError('INVALID_SOURCE', 'PDF source URL is too long', 400);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new PdfSourceError('INVALID_SOURCE', 'Invalid PDF source URL', 400);
+  }
+
+  if (parsed.username || parsed.password) {
+    throw new PdfSourceError('INVALID_SOURCE', 'URL credentials are not allowed', 400);
+  }
+
+  if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && process.env.NODE_ENV !== 'production')) {
+    throw new PdfSourceError('INVALID_SOURCE', 'Only HTTPS PDF sources are allowed', 400);
+  }
+
+  const matchesConfiguredBase = configuredStorageBases().some((base) => {
+    if (parsed.origin !== base.origin) return false;
+    if (base.pathPrefix === '/') return true;
+    return parsed.pathname === base.pathPrefix.slice(0, -1)
+      || parsed.pathname.startsWith(base.pathPrefix);
+  });
+
+  if (!matchesConfiguredBase) {
+    throw new PdfSourceError('INVALID_SOURCE', 'PDF source is not an approved storage origin', 403);
+  }
+
+  return parsed;
+}
+
+function isWithin(baseDir: string, candidate: string): boolean {
+  const relative = path.relative(baseDir, candidate);
+  return relative.length > 0 && !relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative);
+}
+
+export function resolveManagedLocalPdfPath(value: string): string {
+  if (!value.startsWith('/')) {
+    throw new PdfSourceError('INVALID_SOURCE', 'Invalid local PDF source', 400);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value, 'http://local.invalid');
+  } catch {
+    throw new PdfSourceError('INVALID_SOURCE', 'Invalid local PDF source', 400);
+  }
+
+  let encodedRelativePath: string;
+  if (parsed.pathname.startsWith('/api/files/generated/')) {
+    encodedRelativePath = parsed.pathname.slice('/api/files/generated/'.length);
+  } else if (parsed.pathname.startsWith('/generated/')) {
+    encodedRelativePath = parsed.pathname.slice('/generated/'.length);
+  } else {
+    throw new PdfSourceError('INVALID_SOURCE', 'Local PDF source is outside generated storage', 400);
+  }
+
+  let relativePath: string;
+  try {
+    relativePath = decodeURIComponent(encodedRelativePath);
+  } catch {
+    throw new PdfSourceError('INVALID_SOURCE', 'Invalid encoded PDF path', 400);
+  }
+
+  if (!relativePath || relativePath.includes('\0') || path.extname(relativePath).toLowerCase() !== '.pdf') {
+    throw new PdfSourceError('INVALID_SOURCE', 'Only generated PDF files are allowed', 400);
+  }
+
+  const baseDir = path.resolve(getGeneratedDir());
+  const candidate = path.resolve(baseDir, relativePath);
+  if (!isWithin(baseDir, candidate)) {
+    throw new PdfSourceError('INVALID_SOURCE', 'PDF path escapes generated storage', 403);
+  }
+
+  return candidate;
+}
+
+export function assertPdfBuffer(buffer: Buffer): void {
+  const headerWindow = buffer.subarray(0, Math.min(buffer.length, 1024));
+  if (headerWindow.indexOf(PDF_HEADER) === -1) {
+    throw new PdfSourceError('INVALID_PDF', 'Source is not a valid PDF', 415);
+  }
+}
+
+async function readResponseBody(response: Response, maxBytes: number): Promise<Buffer> {
+  const declaredLength = response.headers.get('content-length');
+  if (declaredLength) {
+    const parsedLength = Number.parseInt(declaredLength, 10);
+    if (Number.isFinite(parsedLength) && parsedLength > maxBytes) {
+      throw new PdfSourceError('PDF_TOO_LARGE', 'PDF source exceeds the size limit', 413);
+    }
+  }
+
+  if (!response.body) {
+    throw new PdfSourceError('FETCH_FAILED', 'PDF source returned an empty response', 502);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel('PDF source exceeds the size limit').catch(() => undefined);
+        throw new PdfSourceError('PDF_TOO_LARGE', 'PDF source exceeds the size limit', 413);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks, totalBytes);
+}
+
+async function fetchTrustedRemotePdf(
+  value: string,
+  maxBytes: number,
+  requestedTimeoutMs?: number
+): Promise<Buffer> {
+  const url = validateTrustedRemotePdfUrl(value);
+  const configuredTimeoutMs = getFetchTimeoutMs();
+  const timeoutMs = requestedTimeoutMs === undefined
+    ? configuredTimeoutMs
+    : Math.min(configuredTimeoutMs, requestedTimeoutMs);
+
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new PdfSourceError('FETCH_FAILED', 'PDF source request timed out', 504);
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url.toString(), {
+      redirect: 'error',
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new PdfSourceError('NOT_FOUND', 'PDF source was not found', 404);
+      }
+      throw new PdfSourceError('FETCH_FAILED', 'Unable to retrieve PDF source', 502);
+    }
+
+    const buffer = await readResponseBody(response, maxBytes);
+    assertPdfBuffer(buffer);
+    return buffer;
+  } catch (error) {
+    if (error instanceof PdfSourceError) throw error;
+    if (controller.signal.aborted) {
+      throw new PdfSourceError('FETCH_FAILED', 'PDF source request timed out', 504);
+    }
+    throw new PdfSourceError('FETCH_FAILED', 'Unable to retrieve PDF source', 502);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function readManagedLocalPdf(value: string, maxBytes: number): Buffer {
+  const filePath = resolveManagedLocalPdfPath(value);
+  if (!fs.existsSync(filePath)) {
+    throw new PdfSourceError('NOT_FOUND', 'PDF source was not found', 404);
+  }
+
+  let realBaseDir: string;
+  let realFilePath: string;
+  try {
+    realBaseDir = fs.realpathSync(path.resolve(getGeneratedDir()));
+    realFilePath = fs.realpathSync(filePath);
+  } catch {
+    throw new PdfSourceError('NOT_FOUND', 'PDF source was not found', 404);
+  }
+
+  if (!isWithin(realBaseDir, realFilePath)) {
+    throw new PdfSourceError('INVALID_SOURCE', 'PDF path escapes generated storage', 403);
+  }
+
+  const stat = fs.statSync(realFilePath);
+  if (!stat.isFile()) {
+    throw new PdfSourceError('INVALID_SOURCE', 'PDF source is not a file', 400);
+  }
+  if (stat.size > maxBytes) {
+    throw new PdfSourceError('PDF_TOO_LARGE', 'PDF source exceeds the size limit', 413);
+  }
+
+  const buffer = fs.readFileSync(realFilePath);
+  if (buffer.length > maxBytes) {
+    throw new PdfSourceError('PDF_TOO_LARGE', 'PDF source exceeds the size limit', 413);
+  }
+  assertPdfBuffer(buffer);
+  return buffer;
+}
+
+export async function loadTrustedPdf(
+  value: string,
+  maxBytes = getMaxPdfSourceBytes(),
+  options: LoadTrustedPdfOptions = {}
+): Promise<TrustedPdf> {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new PdfSourceError('INVALID_SOURCE', 'PDF source is required', 400);
+  }
+
+  if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) {
+    throw new PdfSourceError('INVALID_SOURCE', 'Invalid PDF source size limit', 500);
+  }
+
+  // Callers may request a smaller budget (for example, the remaining ZIP
+  // budget), but may never raise the configured per-source ceiling.
+  const effectiveMaxBytes = Math.min(maxBytes, getMaxPdfSourceBytes());
+
+  if (/^https?:\/\//i.test(value)) {
+    return {
+      buffer: await fetchTrustedRemotePdf(value, effectiveMaxBytes, options.timeoutMs),
+      source: 'remote'
+    };
+  }
+
+  return { buffer: readManagedLocalPdf(value, effectiveMaxBytes), source: 'local' };
+}
+
+export function sanitizePdfFilename(value: unknown, fallback = 'download.pdf'): string {
+  const fallbackBasename = path.basename(fallback).replace(/[^a-zA-Z0-9._ -]/g, '_') || 'download';
+  const fallbackStem = fallbackBasename.toLowerCase().endsWith('.pdf')
+    ? fallbackBasename.slice(0, -4)
+    : fallbackBasename;
+  const safeFallback = `${fallbackStem.slice(0, 176).replace(/[ .]+$/, '') || 'download'}.pdf`;
+  if (typeof value !== 'string') return safeFallback;
+
+  const basename = path.basename(value)
+    .replace(/[^a-zA-Z0-9._ -]/g, '_')
+    .replace(/^\.+/, '')
+    .trim();
+  if (!basename) return safeFallback;
+
+  const stem = basename.toLowerCase().endsWith('.pdf') ? basename.slice(0, -4) : basename;
+  const safeStem = stem.slice(0, 176).replace(/[ .]+$/, '') || 'download';
+  return `${safeStem}.pdf`;
+}

--- a/pages/api/force-download.ts
+++ b/pages/api/force-download.ts
@@ -1,9 +1,21 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { isR2Configured } from '@/lib/r2-client';
-import fs from 'fs';
-import path from 'path';
+import { requireAuth } from '@/lib/auth/requireAuth';
+import { enforceRateLimit } from '@/lib/rate-limit';
+import {
+  loadTrustedPdf,
+  PdfSourceError,
+  sanitizePdfFilename,
+} from '@/lib/security/trusted-pdf-source';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const session = await requireAuth(req, res);
+  if (!session) return;
+
   const { url, filename } = req.query;
   
   if (!url || typeof url !== 'string') {
@@ -11,65 +23,33 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  const downloadFilename = (filename && typeof filename === 'string') ? filename : 'download.pdf';
+  const userId = (session.user as any).id as string;
+  const rateLimit = enforceRateLimit(req, res, {
+    userId,
+    route: 'force-download',
+    category: 'download',
+  });
+  if (!rateLimit.allowed) {
+    res.status(429).json({ error: 'Too many downloads. Please wait and try again.' });
+    return;
+  }
+
+  const downloadFilename = sanitizePdfFilename(filename);
 
   try {
-    // Set download headers
+    const { buffer } = await loadTrustedPdf(url);
+
     res.setHeader('Content-Type', 'application/pdf');
     res.setHeader('Content-Disposition', `attachment; filename="${downloadFilename}"`);
-
-    if (isR2Configured() && (url.includes('.r2.cloudflarestorage.com') || (process.env.R2_PUBLIC_URL && url.startsWith(process.env.R2_PUBLIC_URL)))) {
-      // Fetch from R2 (either direct endpoint or custom domain) and stream to response
-      console.log('Downloading from R2:', url);
-      const response = await fetch(url);
-      
-      if (!response.ok) {
-        console.error(`Failed to fetch from R2: ${response.status}`);
-        res.status(404).json({ error: 'File not found' });
-        return;
-      }
-
-      // Stream the response
-      const buffer = await response.arrayBuffer();
-      res.send(Buffer.from(buffer));
-    } else {
-      // Handle local files
-      const parsedUrl = new URL(url, `http://localhost:3000`);
-      let filePath: string;
-
-      if (parsedUrl.pathname.startsWith('/api/files/generated/')) {
-        const relativePath = parsedUrl.pathname.replace(/^\/api\/files\/generated\//, '');
-        filePath = path.join(process.cwd(), 'public', 'generated', relativePath);
-      } else if (parsedUrl.pathname.startsWith('/generated/')) {
-        const relativePath = parsedUrl.pathname.replace(/^\/generated\//, '');
-        filePath = path.join(process.cwd(), 'public', 'generated', relativePath);
-      } else {
-        res.status(400).json({ error: 'Invalid URL format' });
-        return;
-      }
-
-      // Security check
-      const normalizedPath = path.normalize(filePath);
-      const generatedDir = path.join(process.cwd(), 'public', 'generated');
-      if (!normalizedPath.startsWith(generatedDir)) {
-        res.status(400).json({ error: 'Invalid file path' });
-        return;
-      }
-
-      // Check if file exists and stream it
-      if (!fs.existsSync(filePath)) {
-        res.status(404).json({ error: 'File not found' });
-        return;
-      }
-
-      const fileBuffer = fs.readFileSync(filePath);
-      res.send(fileBuffer);
-    }
+    res.setHeader('Cache-Control', 'private, no-store');
+    res.send(buffer);
   } catch (error) {
-    console.error('Download error:', error);
-    if (!res.headersSent) {
-      res.status(500).json({ error: 'Failed to download file' });
+    if (error instanceof PdfSourceError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
     }
+    console.error('Download failed:', error);
+    res.status(500).json({ error: 'Failed to download file' });
     return;
   }
 }

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -5,6 +5,26 @@ import { EmailParams } from '@/lib/email/types';
 import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
+import {
+  getMaxPdfSourceBytes,
+  PdfSourceError,
+} from '@/lib/security/trusted-pdf-source';
+
+const MAX_BULK_EMAILS = 500;
+const BULK_ATTACHMENT_CONCURRENCY = 4;
+const DEFAULT_MAX_BULK_ATTACHMENT_BYTES = 100 * 1024 * 1024;
+const HARD_MAX_BULK_ATTACHMENT_BYTES = 250 * 1024 * 1024;
+
+function getMaxBulkAttachmentBytes(): number {
+  const configured = Number.parseInt(
+    process.env.MAX_BULK_EMAIL_ATTACHMENT_BYTES || '',
+    10
+  );
+  if (!Number.isSafeInteger(configured) || configured <= 0) {
+    return DEFAULT_MAX_BULK_ATTACHMENT_BYTES;
+  }
+  return Math.min(configured, HARD_MAX_BULK_ATTACHMENT_BYTES);
+}
 
 export const config = {
   api: {
@@ -48,6 +68,13 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
 
     if (!emails || !Array.isArray(emails) || emails.length === 0) {
       res.status(400).json({ error: 'No emails provided' });
+      return;
+    }
+
+    if (emails.length > MAX_BULK_EMAILS) {
+      res.status(413).json({
+        error: `A bulk request can contain at most ${MAX_BULK_EMAILS} emails`
+      });
       return;
     }
 
@@ -115,26 +142,66 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
       return;
     }
 
-    // Add emails to queue
-    const emailParams = await Promise.all(emailsWithRecipients.map(async email => {
-      // Build attachments from client-side data or server-side URLs
-      const attachments = await buildPdfAttachments({
-        attachmentData: email.attachmentData,
-        attachments: email.attachments
-      });
+    // Build attachments with bounded concurrency and a request-wide byte
+    // budget. Per-email limits alone are insufficient because a single bulk
+    // request can otherwise fan out hundreds of simultaneous remote reads.
+    const emailParams: Array<EmailParams & { certificateUrl?: string }> = [];
+    const maxBulkAttachmentBytes = getMaxBulkAttachmentBytes();
+    let totalAttachmentBytes = 0;
 
-      return {
-        to: email.recipients,
-        from: email.senderName
-          ? `${email.senderName} <${fromAddress}>`
-          : `Bamboobot Certificates <${fromAddress}>`,
-        subject: email.subject,
-        html: email.html,
-        text: email.text,
-        attachments,
-        certificateUrl: email.certificateUrl
-      };
-    }));
+    for (let offset = 0; offset < emailsWithRecipients.length; offset += BULK_ATTACHMENT_CONCURRENCY) {
+      const batch = emailsWithRecipients.slice(offset, offset + BULK_ATTACHMENT_CONCURRENCY);
+      const emailsWithAttachments = batch.filter((email) =>
+        email.attachmentData !== undefined
+        || email.attachments?.some((attachment) => Boolean(attachment?.path || attachment?.content))
+      ).length;
+      const remainingBytes = maxBulkAttachmentBytes - totalAttachmentBytes;
+
+      if (emailsWithAttachments > 0 && remainingBytes < emailsWithAttachments) {
+        throw new PdfSourceError('PDF_TOO_LARGE', 'Bulk PDF attachments exceed the size limit', 413);
+      }
+
+      const perEmailBudget = emailsWithAttachments > 0
+        ? Math.min(
+            getMaxPdfSourceBytes(),
+            Math.floor(remainingBytes / emailsWithAttachments)
+          )
+        : getMaxPdfSourceBytes();
+
+      const builtBatch = await Promise.all(batch.map(async email => {
+        const attachments = await buildPdfAttachments({
+          attachmentData: email.attachmentData,
+          attachments: email.attachments,
+          maxTotalBytes: perEmailBudget,
+        });
+
+        return {
+          to: email.recipients,
+          from: email.senderName
+            ? `${email.senderName} <${fromAddress}>`
+            : `Bamboobot Certificates <${fromAddress}>`,
+          subject: email.subject,
+          html: email.html,
+          text: email.text,
+          attachments,
+          certificateUrl: email.certificateUrl
+        };
+      }));
+
+      const batchAttachmentBytes = builtBatch.reduce((batchTotal, email) => {
+        return batchTotal + (email.attachments?.reduce(
+          (emailTotal, attachment) => emailTotal + (attachment.content?.length || 0),
+          0
+        ) || 0);
+      }, 0);
+      totalAttachmentBytes += batchAttachmentBytes;
+
+      if (totalAttachmentBytes > maxBulkAttachmentBytes) {
+        throw new PdfSourceError('PDF_TOO_LARGE', 'Bulk PDF attachments exceed the size limit', 413);
+      }
+
+      emailParams.push(...builtBatch);
+    }
 
     await queueManager.addToQueue(emailParams);
 
@@ -151,6 +218,10 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     });
     return;
   } catch (error) {
+    if (error instanceof PdfSourceError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
     console.error('Bulk email error:', error);
     res.status(500).json({
       error: error instanceof Error ? error.message : 'Failed to send emails'

--- a/pages/api/send-email.ts
+++ b/pages/api/send-email.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { withFeatureGate } from '@/lib/server/middleware/featureGate';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
+import { PdfSourceError } from '@/lib/security/trusted-pdf-source';
 
 export const config = {
   api: {
@@ -130,6 +131,10 @@ Important: This download link will expire in 90 days. Please save your certifica
     return;
 
   } catch (error) {
+    if (error instanceof PdfSourceError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
     console.error('Error sending email:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     res.status(500).json({ 

--- a/pages/api/send-test-email.ts
+++ b/pages/api/send-test-email.ts
@@ -4,6 +4,7 @@ import { EmailParams } from '@/lib/email/types';
 import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
+import { PdfSourceError } from '@/lib/security/trusted-pdf-source';
 
 export const config = {
   api: {
@@ -99,6 +100,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       provider: result.provider
     });
   } catch (error) {
+    if (error instanceof PdfSourceError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
     console.error('Test email error:', error);
     res.status(500).json({
       error: error instanceof Error ? error.message : 'Failed to send test email'

--- a/pages/api/zip-pdfs.ts
+++ b/pages/api/zip-pdfs.ts
@@ -1,16 +1,32 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import archiver from 'archiver';
-import { parse } from 'url';
-import path from 'path';
-import fs from 'fs';
-import { isR2Configured } from '@/lib/r2-client';
 import { debug, error } from '@/lib/log';
 import { requireAuth } from '@/lib/auth/requireAuth';
 import { rateLimit, buildKey } from '@/lib/rate-limit';
+import {
+  getMaxPdfSourceBytes,
+  loadTrustedPdf,
+  PdfSourceError,
+  sanitizePdfFilename,
+} from '@/lib/security/trusted-pdf-source';
 
 interface FileInfo {
   url: string;
   filename: string;
+}
+
+const MAX_ZIP_FILES = 500;
+const MAX_ZIP_BYTES = 250 * 1024 * 1024;
+const MAX_SOURCE_FAILURES = 5;
+const DEFAULT_MAX_ZIP_DURATION_MS = 60_000;
+const HARD_MAX_ZIP_DURATION_MS = 120_000;
+
+function getMaxZipDurationMs(): number {
+  const configured = Number.parseInt(process.env.MAX_ZIP_DURATION_MS || '', 10);
+  if (!Number.isSafeInteger(configured) || configured <= 0) {
+    return DEFAULT_MAX_ZIP_DURATION_MS;
+  }
+  return Math.min(configured, HARD_MAX_ZIP_DURATION_MS);
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
@@ -24,6 +40,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (!files || !Array.isArray(files) || files.length === 0) {
     res.status(400).json({ error: 'No files provided' });
+    return;
+  }
+
+  if (files.length > MAX_ZIP_FILES) {
+    res.status(413).json({ error: `A ZIP can contain at most ${MAX_ZIP_FILES} files` });
+    return;
+  }
+
+  if (files.some((file) => !file || typeof file.url !== 'string' || typeof file.filename !== 'string')) {
+    res.status(400).json({ error: 'Each file must include a URL and filename' });
     return;
   }
 
@@ -43,20 +69,37 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
+  let archiveTimeout: NodeJS.Timeout | undefined;
+
   try {
     // Set headers for ZIP download
     res.setHeader('Content-Type', 'application/zip');
     res.setHeader('Content-Disposition', 'attachment; filename="certificates.zip"');
+    res.setHeader('Cache-Control', 'private, no-store');
 
     // Create archive
     const archive = archiver('zip', {
       zlib: { level: 9 } // Maximum compression
     });
 
-    // Handle archive errors
+    let archiveFailure: Error | null = null;
+    let resolveArchiveError!: (reason: Error) => void;
+    const archiveError = new Promise<Error>((resolve) => {
+      resolveArchiveError = resolve;
+    });
+
+    const failArchive = (reason: unknown) => {
+      if (archiveFailure) return;
+      archiveFailure = reason instanceof Error ? reason : new Error('ZIP archive failed');
+      resolveArchiveError(archiveFailure);
+    };
+
+    // Resolve (rather than reject) immediately on archive errors so an event
+    // emitted during an awaited source load cannot become an unhandled
+    // rejection before finalization attaches its race handler.
     archive.on('error', (err) => {
       error('Archive error:', err);
-      throw err;
+      failArchive(err);
     });
 
     // Log when archive is finalized
@@ -67,77 +110,89 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Pipe the archive to the response
     archive.pipe(res);
 
-    // Add each PDF to the archive
-    for (const file of files) {
+    let totalBytes = 0;
+    let sourceFailures = 0;
+    const maxZipDurationMs = getMaxZipDurationMs();
+    const deadlineAt = Date.now() + maxZipDurationMs;
+
+    archiveTimeout = setTimeout(() => {
+      const timeoutError = new Error('ZIP generation timed out');
+      failArchive(timeoutError);
       try {
-        debug(`Processing file: ${file.url} -> ${file.filename}`);
-        
-        // Check if this is an R2 URL (either direct endpoint or custom domain)
-        if (isR2Configured() && (file.url.includes('.r2.cloudflarestorage.com') || (process.env.R2_PUBLIC_URL && file.url.startsWith(process.env.R2_PUBLIC_URL)))) {
-          // Fetch the file from R2
-          debug('Fetching from R2:', file.url);
-          const response = await fetch(file.url);
-          if (!response.ok) {
-            error(`Failed to fetch from R2: ${response.status}`);
-            continue;
-          }
-          const buffer = await response.arrayBuffer();
-          
-          // Add the buffer to archive
-          archive.append(Buffer.from(buffer), { name: file.filename });
-        } else {
-          // Handle local files
-          const parsedUrl = parse(file.url);
-          const urlPath = parsedUrl.pathname || '';
-          debug(`URL path: ${urlPath}`);
-          
-          // Convert URL path to file system path
-          // Handle both direct URLs (/generated/) and API URLs (/api/files/generated/)
-          let relativePath: string;
-          if (urlPath.startsWith('/api/files/generated/')) {
-            relativePath = urlPath.replace(/^\/api\/files\/generated\//, '');
-          } else if (urlPath.startsWith('/generated/')) {
-            relativePath = urlPath.replace(/^\/generated\//, '');
-          } else {
-            console.error(`Unexpected URL format: ${urlPath}`);
-            continue;
-          }
-          
-          const filePath = path.join(process.cwd(), 'public', 'generated', relativePath);
-          debug(`File path: ${filePath}`);
-          
-          // Security check - ensure the file is within the generated directory
-          const normalizedPath = path.normalize(filePath);
-          const generatedDir = path.join(process.cwd(), 'public', 'generated');
-          if (!normalizedPath.startsWith(generatedDir)) {
-            error(`Security error: Invalid file path ${filePath}`);
-            continue;
-          }
+        archive.abort();
+      } catch {
+        // The failure is already recorded and will be surfaced below.
+      }
+    }, maxZipDurationMs);
 
-          // Check if file exists
-          if (!fs.existsSync(filePath)) {
-            error(`File not found: ${filePath}`);
-            continue;
-          }
+    // Add each validated PDF to the archive. Each source and the aggregate
+    // archive input are bounded to avoid turning this endpoint into a memory
+    // or bandwidth amplifier.
+    for (const file of files) {
+      if (archiveFailure) throw archiveFailure;
 
-          // Add the file to the archive
-          archive.file(filePath, { name: file.filename });
+      const remainingDurationMs = deadlineAt - Date.now();
+      if (remainingDurationMs <= 0) {
+        const timeoutError = new Error('ZIP generation timed out');
+        failArchive(timeoutError);
+        throw timeoutError;
+      }
+
+      try {
+        const remainingBytes = MAX_ZIP_BYTES - totalBytes;
+        if (remainingBytes <= 0) {
+          error('ZIP input limit reached; remaining files were skipped');
+          break;
         }
-        
+
+        const { buffer } = await loadTrustedPdf(
+          file.url,
+          Math.min(getMaxPdfSourceBytes(), remainingBytes),
+          { timeoutMs: remainingDurationMs }
+        );
+        if (archiveFailure) throw archiveFailure;
+
+        totalBytes += buffer.length;
+        archive.append(buffer, { name: sanitizePdfFilename(file.filename, 'certificate.pdf') });
       } catch (fileError) {
-        error(`Error processing file ${file.filename}:`, fileError);
+        if (archiveFailure) throw archiveFailure;
+
+        if (fileError instanceof PdfSourceError) {
+          error(`Skipped unsafe or unavailable PDF source (${fileError.code})`);
+          sourceFailures += 1;
+
+          // A too-large source can consume the entire per-file read budget
+          // before being rejected. Stop rather than allowing a request to
+          // repeat that expensive read hundreds of times.
+          if (fileError.code === 'PDF_TOO_LARGE' || sourceFailures >= MAX_SOURCE_FAILURES) {
+            break;
+          }
+        } else {
+          error('Error processing PDF for ZIP:', fileError);
+          sourceFailures += 1;
+          if (sourceFailures >= MAX_SOURCE_FAILURES) break;
+        }
         // Continue with other files
       }
     }
 
     // Finalize the archive
-    await archive.finalize();
+    if (archiveFailure) throw archiveFailure;
+    const finalization = await Promise.race([
+      archiveError.then((failure) => ({ failure })),
+      archive.finalize().then(() => ({ failure: null as Error | null })),
+    ]);
+    if (finalization.failure) throw finalization.failure;
 
   } catch (err) {
     error('ZIP creation error:', err);
     if (!res.headersSent) {
       res.status(500).json({ error: 'Failed to create ZIP file' });
+    } else if (!res.writableEnded && typeof res.destroy === 'function') {
+      res.destroy(err instanceof Error ? err : undefined);
     }
     return;
+  } finally {
+    if (archiveTimeout) clearTimeout(archiveTimeout);
   }
 }

--- a/utils/email-utils.ts
+++ b/utils/email-utils.ts
@@ -8,6 +8,16 @@
  * to avoid bundling Buffer polyfills.
  */
 
+import {
+  assertPdfBuffer,
+  getMaxPdfSourceBytes,
+  loadTrustedPdf,
+  PdfSourceError,
+  sanitizePdfFilename,
+} from '@/lib/security/trusted-pdf-source';
+
+const DEFAULT_MAX_EMAIL_ATTACHMENTS = 10;
+
 // Re-export browser-safe functions for server-side convenience
 export {
   isValidEmail,
@@ -44,6 +54,10 @@ export interface BuildAttachmentsOptions {
   attachmentUrl?: string;
   /** Default filename if not provided elsewhere */
   defaultFilename?: string;
+  /** Maximum combined attachment bytes for this email */
+  maxTotalBytes?: number;
+  /** Maximum number of attachments for this email */
+  maxAttachments?: number;
 }
 
 export interface BuiltAttachment {
@@ -55,19 +69,59 @@ export interface BuiltAttachment {
 /**
  * Fetch a PDF from URL and return as Buffer
  */
-async function fetchPdfBuffer(url: string): Promise<Buffer | null> {
+async function fetchPdfBuffer(url: string, maxBytes: number): Promise<Buffer> {
   try {
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.error(`Failed to fetch attachment from ${url}: ${response.status}`);
-      return null;
-    }
-    const arrayBuffer = await response.arrayBuffer();
-    return Buffer.from(arrayBuffer);
+    const { buffer } = await loadTrustedPdf(url, maxBytes);
+    return buffer;
   } catch (error) {
-    console.error('Error fetching attachment:', error);
-    return null;
+    if (error instanceof PdfSourceError) {
+      console.warn(`Rejected or unavailable PDF attachment source (${error.code})`);
+      throw error;
+    }
+    console.error('Error loading PDF attachment:', error);
+    throw new PdfSourceError('FETCH_FAILED', 'Unable to load PDF attachment', 502);
   }
+}
+
+function positiveLimit(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && (value as number) > 0 ? value as number : fallback;
+}
+
+function validateInlinePdf(buffer: Buffer, remainingBytes: number): void {
+  if (buffer.length > remainingBytes) {
+    throw new PdfSourceError('PDF_TOO_LARGE', 'PDF attachments exceed the size limit', 413);
+  }
+  assertPdfBuffer(buffer);
+}
+
+function decodeBase64Pdf(value: string, maxBytes: number): Buffer {
+  // Base64 expands binary data by roughly 4/3. Reject from the encoded length
+  // before allocating the decoded Buffer, then enforce the exact byte count.
+  const maxEncodedLength = Math.ceil(maxBytes / 3) * 4 + 4;
+  if (value.length > maxEncodedLength) {
+    throw new PdfSourceError('PDF_TOO_LARGE', 'PDF attachment exceeds the size limit', 413);
+  }
+
+  const buffer = Buffer.from(value, 'base64');
+  if (buffer.length > maxBytes) {
+    throw new PdfSourceError('PDF_TOO_LARGE', 'PDF attachment exceeds the size limit', 413);
+  }
+  return buffer;
+}
+
+function bufferFromPdfBytes(value: unknown, maxBytes: number): Buffer {
+  if (!Array.isArray(value) && !(value instanceof Uint8Array)) {
+    throw new PdfSourceError('INVALID_PDF', 'Invalid PDF attachment byte data', 400);
+  }
+  if (value.length > maxBytes) {
+    throw new PdfSourceError('PDF_TOO_LARGE', 'PDF attachment exceeds the size limit', 413);
+  }
+  if (Array.isArray(value) && value.some((byte) =>
+    !Number.isInteger(byte) || byte < 0 || byte > 255
+  )) {
+    throw new PdfSourceError('INVALID_PDF', 'Invalid PDF attachment byte data', 400);
+  }
+  return Buffer.from(value);
 }
 
 /**
@@ -86,8 +140,30 @@ async function fetchPdfBuffer(url: string): Promise<Buffer | null> {
 export async function buildPdfAttachments(
   options: BuildAttachmentsOptions
 ): Promise<BuiltAttachment[] | undefined> {
-  const { attachmentData, attachment, attachments, attachmentUrl, defaultFilename = 'certificate.pdf' } = options;
+  const {
+    attachmentData,
+    attachment,
+    attachments,
+    attachmentUrl,
+    defaultFilename = 'certificate.pdf',
+  } = options;
+  const configuredMaxBytes = getMaxPdfSourceBytes();
+  const maxTotalBytes = Math.min(
+    positiveLimit(options.maxTotalBytes, configuredMaxBytes),
+    configuredMaxBytes
+  );
+  const maxAttachments = positiveLimit(options.maxAttachments, DEFAULT_MAX_EMAIL_ATTACHMENTS);
   const result: BuiltAttachment[] = [];
+
+  const appendAttachment = (buffer: Buffer, filename: string) => {
+    const usedBytes = result.reduce((total, item) => total + item.content.length, 0);
+    validateInlinePdf(buffer, maxTotalBytes - usedBytes);
+    result.push({
+      filename: sanitizePdfFilename(filename, defaultFilename),
+      content: buffer,
+      contentType: 'application/pdf'
+    });
+  };
 
   // Handle client-side PDF data (various formats)
   if (attachmentData) {
@@ -96,85 +172,62 @@ export async function buildPdfAttachments(
 
     if (typeof attachmentData === 'string') {
       // Base64 string
-      buffer = Buffer.from(attachmentData, 'base64');
+      buffer = decodeBase64Pdf(attachmentData, maxTotalBytes);
     } else if (Array.isArray(attachmentData)) {
       // Raw number array (Uint8Array serialised)
-      buffer = Buffer.from(attachmentData);
+      buffer = bufferFromPdfBytes(attachmentData, maxTotalBytes);
     } else if (attachmentData.data) {
       // Object with data property
-      buffer = Buffer.from(attachmentData.data);
+      buffer = bufferFromPdfBytes(attachmentData.data, maxTotalBytes);
       if (attachmentData.filename) {
         filename = attachmentData.filename;
       }
     }
 
     if (buffer) {
-      result.push({
-        filename,
-        content: buffer,
-        contentType: 'application/pdf'
-      });
+      appendAttachment(buffer, filename);
       return result;
     }
   }
 
   // Handle single server-side attachment with path
   if (attachment?.path) {
-    const buffer = await fetchPdfBuffer(attachment.path);
-    if (buffer) {
-      result.push({
-        filename: attachment.filename || defaultFilename,
-        content: buffer,
-        contentType: 'application/pdf'
-      });
-      return result;
-    }
+    const buffer = await fetchPdfBuffer(attachment.path, maxTotalBytes);
+    appendAttachment(buffer, attachment.filename || defaultFilename);
+    return result;
   }
 
   // Handle array of server-side attachments
   if (attachments && attachments.length > 0) {
-    const fetched = await Promise.all(
-      attachments.map(async (att) => {
-        if (att.path) {
-          const buffer = await fetchPdfBuffer(att.path);
-          if (buffer) {
-            return {
-              filename: att.filename || defaultFilename,
-              content: buffer,
-              contentType: 'application/pdf'
-            };
-          }
-        } else if (att.content) {
-          // Already has content
-          return {
-            filename: att.filename || defaultFilename,
-            content: typeof att.content === 'string'
-              ? Buffer.from(att.content, 'base64')
-              : att.content as Buffer,
-            contentType: 'application/pdf'
-          };
-        }
-        return null;
-      })
-    );
+    if (attachments.length > maxAttachments) {
+      throw new PdfSourceError('PDF_TOO_LARGE', 'Too many PDF attachments', 413);
+    }
 
-    const valid = fetched.filter((a): a is BuiltAttachment => a !== null);
-    if (valid.length > 0) {
-      return valid;
+    for (const att of attachments) {
+      const usedBytes = result.reduce((total, item) => total + item.content.length, 0);
+      const remainingBytes = maxTotalBytes - usedBytes;
+
+      if (att.path) {
+        const buffer = await fetchPdfBuffer(att.path, remainingBytes);
+        appendAttachment(buffer, att.filename || defaultFilename);
+      } else if (att.content) {
+        const buffer = typeof att.content === 'string'
+          ? decodeBase64Pdf(att.content, remainingBytes)
+          : bufferFromPdfBytes(att.content as Buffer, remainingBytes);
+        appendAttachment(buffer, att.filename || defaultFilename);
+      }
+    }
+
+    if (result.length > 0) {
+      return result;
     }
   }
 
   // Handle direct attachment URL
   if (attachmentUrl) {
-    const buffer = await fetchPdfBuffer(attachmentUrl);
-    if (buffer) {
-      result.push({
-        filename: defaultFilename,
-        content: buffer,
-        contentType: 'application/pdf'
-      });
-      return result;
-    }
+    const buffer = await fetchPdfBuffer(attachmentUrl, maxTotalBytes);
+    appendAttachment(buffer, defaultFilename);
+    return result;
   }
 
   return undefined;


### PR DESCRIPTION
## Summary

- centralize server-side PDF loading behind exact configured storage-origin and managed-local-path validation
- disable redirects, reject URL credentials, enforce per-source byte and timeout ceilings, validate PDF magic, and sanitize filenames
- apply the loader to forced downloads, ZIP assembly, email attachments, and the SES provider fallback
- bound ZIP duration/input/failures and bulk-email attachment count, bytes, and concurrency
- add auth/rate limiting and fail-closed error handling at affected API boundaries

## Security invariants

- remote sources must match an exact operator-configured R2, S3, or CloudFront origin (and configured path prefix)
- local sources must resolve beneath generated storage after percent-decoding and realpath checks
- redirects are never followed; remote bodies are streamed only up to the configured cap
- callers cannot raise the configured per-source ceiling
- ZIP work is capped by file count, bytes, source failures, and a whole-operation deadline
- email attachment decoding and bulk fan-out have pre-allocation, per-email, aggregate, and concurrency bounds
- SES raw MIME headers and attachment filenames reject header injection

## Verification

- `npm test -- --runInBand` — 39 suites passed, 420 tests passed, 1 skipped
- focused security/API suite — 10 suites passed, 55 tests passed
- `npm run build` — production build passed
- `git diff --check` — passed
- Claude `-p` adversarial gate — `VERDICT: CLEAN`
- independent ultra adversarial gate — `VERDICT: CLEAN`

## Scope

Cross-tenant object ownership and the remaining security-audit findings are intentionally handled in follow-up PRs so each fix can be reviewed and merged independently.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->