### PR TITLE
security: enforce runtime authentication gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,10 @@ NODE_ENV=development
 # Disable Next.js telemetry
 NEXT_TELEMETRY_DISABLED=1
 
-# Require auth gating (set true in staging/prod when ready)
-NEXT_PUBLIC_REQUIRE_AUTH=false
+# Server-only runtime auth gate. Production defaults to enabled when omitted.
+# Setting false removes the global login wall, including from APIs. Use it only
+# in a trusted local environment; only endpoints with their own checks remain protected.
+REQUIRE_AUTH=true
 
 # Enable server persistence for projects (client-visible flag)
 NEXT_PUBLIC_PROJECT_SERVER_PERSISTENCE=false
@@ -161,7 +163,7 @@ DATABASE_URL="file:./prisma/database.db"
 # USER TIER CONFIGURATION
 # ========================================
 # Auto-elevate users to admin/super_admin based on email
-# These settings only apply when authentication is enabled (NEXT_PUBLIC_REQUIRE_AUTH=true)
+# These settings only apply when authentication is enabled (REQUIRE_AUTH=true)
 
 # Super Admin emails (comma-separated, highest privileges)
 # Users with these exact email addresses get super_admin tier

--- a/DEPLOYMENT_INSTRUCTIONS.md
+++ b/DEPLOYMENT_INSTRUCTIONS.md
@@ -33,8 +33,13 @@ NEXTAUTH_SECRET=your_generated_secret  # Generate with: openssl rand -base64 32
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 
+# Authentication (server-only and evaluated at runtime)
+# Production defaults to enabled when this is omitted or invalid.
+# Keep enabled in production. False removes the global wall, including from APIs;
+# only endpoints with their own checks remain protected.
+REQUIRE_AUTH=true
+
 # Feature Flags
-NEXT_PUBLIC_REQUIRE_AUTH=false  # Set to true when ready
 NEXT_PUBLIC_PROJECT_SERVER_PERSISTENCE=false  # Enable server storage when ready
 
 # Admin Configuration (if using auth)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Generate beautiful, personalised certificates from an image background with drag
 
 ### Authentication & Access Control
 - **Google Sign‑in (NextAuth)** with JWT sessions
-- **Route Gating** via `NEXT_PUBLIC_REQUIRE_AUTH=true` (everything except `/` + static assets)
+- **Route Gating** via the server-only runtime setting `REQUIRE_AUTH=true` (everything except `/` + static assets)
 - **Marketing Landing** at `/`; signed‑in users redirect to `/app`
 
 ### Persistence & Migration
@@ -84,14 +84,14 @@ docker-compose -f docker-compose.dev.yml up -d
 
 ## Authentication
 
-- Set `NEXT_PUBLIC_REQUIRE_AUTH=true` to gate the app behind login. Public landing remains available at `/`.
+- Set `REQUIRE_AUTH=true` to gate app pages and APIs behind login while keeping the public landing page available at `/`. This server-only setting is evaluated at runtime; production defaults to authentication enabled when it is omitted or invalid. Setting it to `false` removes the global middleware login wall, including from APIs; use it only in a trusted local environment. Only endpoints with their own authorization checks remain protected.
 - Configure Google provider in `.env` and set `NEXTAUTH_SECRET`.
 - Admin dashboard at `/dashboard` is gated by `ADMIN_EMAILS` (comma‑separated emails).
 
 Example env snippet:
 
 ```bash
-NEXT_PUBLIC_REQUIRE_AUTH=true
+REQUIRE_AUTH=true
 NEXTAUTH_SECRET=replace-with-random-string
 GOOGLE_CLIENT_ID=...apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=...

--- a/__tests__/lib/runtime-auth-policy.test.ts
+++ b/__tests__/lib/runtime-auth-policy.test.ts
@@ -1,0 +1,69 @@
+import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
+
+describe('isAuthenticationRequired', () => {
+  const originalRequireAuth = process.env.REQUIRE_AUTH;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  function setNodeEnv(value: string): void {
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value,
+    });
+  }
+
+  afterEach(() => {
+    if (originalRequireAuth === undefined) delete process.env.REQUIRE_AUTH;
+    else process.env.REQUIRE_AUTH = originalRequireAuth;
+    setNodeEnv(originalNodeEnv ?? 'test');
+    delete process.env.NEXT_PUBLIC_REQUIRE_AUTH;
+  });
+
+  it('defaults to enabled in production', () => {
+    delete process.env.REQUIRE_AUTH;
+    setNodeEnv('production');
+
+    expect(isAuthenticationRequired()).toBe(true);
+  });
+
+  it.each(['development', 'test'])('defaults to disabled in %s', nodeEnv => {
+    delete process.env.REQUIRE_AUTH;
+    setNodeEnv(nodeEnv);
+
+    expect(isAuthenticationRequired()).toBe(false);
+  });
+
+  it.each(['1', 'true', 'TRUE', ' yes ', 'on'])('accepts enabled value %p', value => {
+    process.env.REQUIRE_AUTH = value;
+    expect(isAuthenticationRequired()).toBe(true);
+  });
+
+  it.each(['0', 'false', 'FALSE', ' no ', 'off'])('accepts disabled value %p', value => {
+    process.env.REQUIRE_AUTH = value;
+    expect(isAuthenticationRequired()).toBe(false);
+  });
+
+  it('fails closed for an invalid value', () => {
+    process.env.REQUIRE_AUTH = 'maybe';
+    setNodeEnv('development');
+
+    expect(isAuthenticationRequired()).toBe(true);
+  });
+
+  it('reads the setting on every call', () => {
+    process.env.REQUIRE_AUTH = 'false';
+    expect(isAuthenticationRequired()).toBe(false);
+
+    process.env.REQUIRE_AUTH = 'true';
+    expect(isAuthenticationRequired()).toBe(true);
+  });
+
+  it('ignores the former public build-time setting', () => {
+    delete process.env.REQUIRE_AUTH;
+    setNodeEnv('production');
+    process.env.NEXT_PUBLIC_REQUIRE_AUTH = 'false';
+
+    expect(isAuthenticationRequired()).toBe(true);
+  });
+});

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -37,6 +37,8 @@ describe('authentication middleware', () => {
     '/api/auth/session',
     '/_next/static/app.js',
     '/logo.png',
+    '/pdf-worker.js',
+    '/fonts/Rubik-Regular.ttf',
     '/generated/progressive_session/certificate.pdf',
   ])(
     'allows public path %s without reading a token',
@@ -57,7 +59,11 @@ describe('authentication middleware', () => {
     expect(response.headers.get('location')).toBe('https://certificates.example/');
   });
 
-  it.each(['/api/projects', '/api/files/generated/certificate.pdf'])(
+  it.each([
+    '/api/projects',
+    '/api/files/generated/certificate.pdf',
+    '/api/export/report.js',
+  ])(
     'rejects unauthenticated API request %s',
     async pathname => {
       mockedGetToken.mockResolvedValue(null);

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,91 @@
+/** @jest-environment node */
+
+import { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { middleware } from '@/middleware';
+
+jest.mock('next-auth/jwt', () => ({
+  getToken: jest.fn(),
+}));
+
+const mockedGetToken = getToken as jest.MockedFunction<typeof getToken>;
+
+function request(pathname: string): NextRequest {
+  return new NextRequest(`https://certificates.example${pathname}`);
+}
+
+describe('authentication middleware', () => {
+  beforeEach(() => {
+    process.env.REQUIRE_AUTH = 'true';
+    process.env.NEXTAUTH_SECRET = 'test-secret';
+    mockedGetToken.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.REQUIRE_AUTH;
+    delete process.env.NEXTAUTH_SECRET;
+  });
+
+  it('allows the public landing page without reading a token', async () => {
+    const response = await middleware(request('/'));
+
+    expect(response.status).toBe(200);
+    expect(mockedGetToken).not.toHaveBeenCalled();
+  });
+
+  it.each(['/api/auth/session', '/_next/static/app.js', '/logo.png'])(
+    'allows public path %s without reading a token',
+    async pathname => {
+      const response = await middleware(request(pathname));
+
+      expect(response.status).toBe(200);
+      expect(mockedGetToken).not.toHaveBeenCalled();
+    },
+  );
+
+  it('redirects an unauthenticated page request to the landing page', async () => {
+    mockedGetToken.mockResolvedValue(null);
+
+    const response = await middleware(request('/app'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://certificates.example/');
+  });
+
+  it.each(['/api/projects', '/api/files/generated/certificate.pdf'])(
+    'rejects unauthenticated API request %s',
+    async pathname => {
+      mockedGetToken.mockResolvedValue(null);
+
+      const response = await middleware(request(pathname));
+
+      expect(response.status).toBe(401);
+      expect(await response.text()).toBe('Unauthorized');
+    },
+  );
+
+  it('does not treat an API auth lookalike as a public auth endpoint', async () => {
+    mockedGetToken.mockResolvedValue(null);
+
+    const response = await middleware(request('/api/authentication'));
+
+    expect(response.status).toBe(401);
+  });
+
+  it('allows an authenticated request', async () => {
+    mockedGetToken.mockResolvedValue({ sub: 'user-1' });
+
+    const response = await middleware(request('/app'));
+
+    expect(response.status).toBe(200);
+  });
+
+  it('allows requests when authentication is explicitly disabled', async () => {
+    process.env.REQUIRE_AUTH = 'false';
+
+    const response = await middleware(request('/api/projects'));
+
+    expect(response.status).toBe(200);
+    expect(mockedGetToken).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -33,7 +33,12 @@ describe('authentication middleware', () => {
     expect(mockedGetToken).not.toHaveBeenCalled();
   });
 
-  it.each(['/api/auth/session', '/_next/static/app.js', '/logo.png'])(
+  it.each([
+    '/api/auth/session',
+    '/_next/static/app.js',
+    '/logo.png',
+    '/generated/progressive_session/certificate.pdf',
+  ])(
     'allows public path %s without reading a token',
     async pathname => {
       const response = await middleware(request(pathname));
@@ -71,6 +76,17 @@ describe('authentication middleware', () => {
 
     expect(response.status).toBe(401);
   });
+
+  it.each(['/private/certificate.pdf', '/generated.pdf'])(
+    'does not exempt PDF path %s outside the legacy generated download directory',
+    async pathname => {
+      mockedGetToken.mockResolvedValue(null);
+
+      const response = await middleware(request(pathname));
+
+      expect(response.status).toBe(307);
+    },
+  );
 
   it('allows an authenticated request', async () => {
     mockedGetToken.mockResolvedValue({ sub: 'user-1' });

--- a/lib/auth/runtime-policy.ts
+++ b/lib/auth/runtime-policy.ts
@@ -1,0 +1,23 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+/**
+ * Returns whether application routes must require authentication.
+ *
+ * REQUIRE_AUTH is intentionally server-only and read for every request so a
+ * single production build can be promoted between environments safely.
+ */
+export function isAuthenticationRequired(): boolean {
+  const configuredValue = process.env['REQUIRE_AUTH'];
+
+  if (configuredValue === undefined || configuredValue.trim() === '') {
+    return process.env['NODE_ENV'] === 'production';
+  }
+
+  const normalizedValue = configuredValue.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalizedValue)) return true;
+  if (FALSE_VALUES.has(normalizedValue)) return false;
+
+  // Unknown security configuration must not silently disable authentication.
+  return true;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,9 @@ import { getToken } from 'next-auth/jwt';
 import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 
 const STATIC_ASSET_PATTERN = /\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif|txt|xml|json|map)$/i;
+// Existing email links rely on this anonymous path. Keep the exception narrow;
+// private/signed certificate delivery will replace it in the storage hardening.
+const LEGACY_PUBLIC_GENERATED_PDF_PATTERN = /^\/generated\/.+\.pdf$/i;
 
 function isPathOrDescendant(pathname: string, path: string): boolean {
   return pathname === path || pathname.startsWith(`${path}/`);
@@ -21,6 +24,7 @@ export async function middleware(req: NextRequest) {
     pathname === '/' ||
     isPathOrDescendant(pathname, '/api/auth') ||
     isPathOrDescendant(pathname, '/_next') ||
+    LEGACY_PUBLIC_GENERATED_PDF_PATTERN.test(pathname) ||
     (!isPathOrDescendant(pathname, '/api') && STATIC_ASSET_PATTERN.test(pathname))
   ) {
     return NextResponse.next();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,27 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
+import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 
-const AUTH_ENABLED = process.env.NEXT_PUBLIC_REQUIRE_AUTH === 'true' || process.env.NEXT_PUBLIC_REQUIRE_AUTH === '1';
+const STATIC_ASSET_PATTERN = /\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif|txt|xml|json|map)$/i;
+
+function isPathOrDescendant(pathname: string, path: string): boolean {
+  return pathname === path || pathname.startsWith(`${path}/`);
+}
 
 export async function middleware(req: NextRequest) {
-  if (!AUTH_ENABLED) return NextResponse.next();
+  if (!isAuthenticationRequired()) return NextResponse.next();
 
   const { pathname } = req.nextUrl;
 
-  // Always allow auth routes, Next internals, and static assets (including root-level files from /public)
+  // Authentication endpoints, framework internals, and public static assets
+  // must remain reachable before a session exists. API paths are never treated
+  // as static assets merely because their final segment has a file extension.
   if (
     pathname === '/' ||
-    pathname.startsWith('/api/auth') ||
-    pathname.startsWith('/_next') ||
-    pathname.startsWith('/favicon') ||
-    pathname.startsWith('/public') ||
-    /\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif|txt|xml|json|map)$/i.test(pathname)
+    isPathOrDescendant(pathname, '/api/auth') ||
+    isPathOrDescendant(pathname, '/_next') ||
+    (!isPathOrDescendant(pathname, '/api') && STATIC_ASSET_PATTERN.test(pathname))
   ) {
     return NextResponse.next();
   }
@@ -43,6 +48,8 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  // Match all routes except Next internals, auth routes, and any path with a file extension
-  matcher: ['/((?!api/auth|_next|favicon|public|.*\\..*).*)'],
+  // Node.js middleware can read server-only environment variables at runtime.
+  // Matching every path ensures API paths ending in a file extension are gated.
+  runtime: 'nodejs',
+  matcher: ['/:path*'],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 
-const STATIC_ASSET_PATTERN = /\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif|txt|xml|json|map)$/i;
+const STATIC_ASSET_PATTERN = /\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif|txt|xml|json|map|js|css|woff|woff2|ttf|otf|eot)$/i;
 // Existing email links rely on this anonymous path. Keep the exception narrow;
 // private/signed certificate delivery will replace it in the storage hardening.
 const LEGACY_PUBLIC_GENERATED_PDF_PATTERN = /^\/generated\/.+\.pdf$/i;

--- a/pages/admin/system.tsx
+++ b/pages/admin/system.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { prisma } from '@/lib/server/prisma';
+import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 import { getTierLimits } from '@/types/user';
 import type { UserTier } from '@/types/user';
 import AdminLayout from '@/components/admin/AdminLayout';
@@ -397,7 +398,7 @@ export const getServerSideProps: GetServerSideProps<SystemPageProps> = async (co
       googleOAuthConfigured: !!process.env.GOOGLE_CLIENT_ID && !!process.env.GOOGLE_CLIENT_SECRET
     },
     configuration: {
-      requireAuth: process.env.NEXT_PUBLIC_REQUIRE_AUTH === 'true',
+      requireAuth: isAuthenticationRequired(),
       projectPersistence: process.env.NEXT_PUBLIC_PROJECT_SERVER_PERSISTENCE === 'true',
       superAdminConfigured: !!(process.env.SUPER_ADMIN_EMAILS || process.env.SUPER_ADMIN_EMAIL),
       adminDomainConfigured: !!(process.env.ADMIN_DOMAINS || process.env.ADMIN_DOMAIN)


### PR DESCRIPTION
## Summary
- replace the build-inlined public auth flag with a server-only runtime policy
- fail closed in production and for invalid configuration
- protect API paths ending in file extensions and tighten public-route boundaries
- document the trusted-local-only implications of disabling the global gate

## Verification
- `npm test -- --runInBand` (41 suites, 447 passed, 1 skipped)
- `REQUIRE_AUTH=false npm run build`
- same built artifact with `REQUIRE_AUTH=true`: `/app` redirects, PDF-shaped API returns 401
- same built artifact with `REQUIRE_AUTH=false`: `/app` serves and API handler executes
- Claude adversarial review: CLEAN
- ultra subagent adversarial review: CLEAN
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->