### PR TITLE
Preserve mixed recipients and paused email queues

### DIFF
--- a/__tests__/api/send-bulk-email.test.ts
+++ b/__tests__/api/send-bulk-email.test.ts
@@ -204,6 +204,29 @@ describe('/api/send-bulk-email', () => {
     expect(JSON.parse(get.res._getData())).toMatchObject({ status: 'idle', total: 0 });
   });
 
+  it('retains paused queues for up to 24 hours', async () => {
+    const post = createMocks({
+      method: 'POST',
+      body: {
+        emails: [{ to: 'paused@example.com', subject: 'Test', html: 'Test' }],
+        config: { senderName: 'Test', subject: 'Test', message: 'Test' },
+        sessionId: 'paused-session',
+        deferProcessing: true
+      }
+    });
+    await handler(post.req, post.res);
+
+    const queueModule = jest.requireMock('@/lib/email/email-queue');
+    const queue = queueModule.EmailQueueManager.mock.results.at(-1).value;
+    queue.getStatus.mockReturnValue({ status: 'paused' });
+    queue.getLastActivity.mockReturnValue(1);
+    await cleanupExpiredEmailQueues(2 * 3600000);
+
+    expect(queue.clear).not.toHaveBeenCalled();
+    await cleanupExpiredEmailQueues(25 * 3600000);
+    expect(queue.clear).toHaveBeenCalledTimes(1);
+  });
+
   it('does not expose or control another user queue with the same session id', async () => {
     const post = createMocks({
       method: 'POST',

--- a/__tests__/api/send-bulk-email.test.ts
+++ b/__tests__/api/send-bulk-email.test.ts
@@ -227,6 +227,45 @@ describe('/api/send-bulk-email', () => {
     expect(queue.clear).toHaveBeenCalledTimes(1);
   });
 
+  it('immediately evicts the oldest paused queue above the global byte cap', async () => {
+    process.env.MAX_PAUSED_EMAIL_ATTACHMENT_BYTES = '20';
+    const inlinePdf = Buffer.from('%PDF-123456789').toString('base64');
+    const createPausedQueue = async (sessionId: string, lastActivity: number) => {
+      const post = createMocks({
+        method: 'POST',
+        body: {
+          emails: [{
+            to: `${sessionId}@example.com`,
+            subject: 'Test',
+            html: 'Test',
+            attachmentData: { data: inlinePdf, filename: `${sessionId}.pdf` }
+          }],
+          config: { senderName: 'Test', subject: 'Test', message: 'Test' },
+          sessionId,
+          deferProcessing: true
+        }
+      });
+      await handler(post.req, post.res);
+      const queueModule = jest.requireMock('@/lib/email/email-queue');
+      const queue = queueModule.EmailQueueManager.mock.results.at(-1).value;
+      queue.getStatus.mockReturnValue({ status: 'paused' });
+      queue.getLastActivity.mockReturnValue(lastActivity);
+      return queue;
+    };
+
+    const oldest = await createPausedQueue('paused-oldest', 1);
+    const newest = await createPausedQueue('paused-newest', 2);
+    const pause = createMocks({
+      method: 'PUT',
+      body: { action: 'pause', sessionId: 'paused-newest' }
+    });
+    await handler(pause.req, pause.res);
+
+    expect(oldest.clear).toHaveBeenCalledTimes(1);
+    expect(newest.clear).not.toHaveBeenCalled();
+    delete process.env.MAX_PAUSED_EMAIL_ATTACHMENT_BYTES;
+  });
+
   it('does not expose or control another user queue with the same session id', async () => {
     const post = createMocks({
       method: 'POST',

--- a/__tests__/components/modals/BulkEmailModal.test.tsx
+++ b/__tests__/components/modals/BulkEmailModal.test.tsx
@@ -51,6 +51,31 @@ describe('BulkEmailModal attachment ingestion', () => {
     expect(screen.queryByText('not-an-email')).not.toBeInTheDocument();
   });
 
+  it('keeps a certificate with at least one valid recipient', () => {
+    render(
+      <BulkEmailModal
+        open
+        onClose={jest.fn()}
+        totalEmails={1}
+        emailConfig={{
+          senderName: 'Sender',
+          subject: 'Certificate',
+          message: 'Attached',
+          deliveryMethod: 'download',
+          isConfigured: true
+        }}
+        certificates={[{
+          email: 'valid@example.com, not-an-email',
+          downloadUrl: '/generated/mixed.pdf',
+          fileName: 'mixed.pdf'
+        }]}
+      />
+    );
+
+    expect(screen.getByText('Ready to send 1 emails:')).toBeInTheDocument();
+    expect(screen.getByText('• valid@example.com, not-an-email')).toBeInTheDocument();
+  });
+
   it('does not post a batch when cancelled during Blob encoding', async () => {
     let finishEncoding!: (value: string) => void;
     mockedBlobToBase64.mockReturnValue(

--- a/__tests__/components/modals/BulkEmailModal.test.tsx
+++ b/__tests__/components/modals/BulkEmailModal.test.tsx
@@ -73,7 +73,9 @@ describe('BulkEmailModal attachment ingestion', () => {
     );
 
     expect(screen.getByText('Ready to send 1 emails:')).toBeInTheDocument();
-    expect(screen.getByText('• valid@example.com, not-an-email')).toBeInTheDocument();
+    expect(screen.getByText('• valid@example.com')).toBeInTheDocument();
+    expect(screen.getByText(/Ignoring invalid addresses in 1 mixed recipient cell/))
+      .toBeInTheDocument();
   });
 
   it('does not post a batch when cancelled during Blob encoding', async () => {

--- a/components/modals/BulkEmailModal.tsx
+++ b/components/modals/BulkEmailModal.tsx
@@ -679,7 +679,9 @@ export function BulkEmailModal({
           open={showPreview}
           onClose={() => setShowPreview(false)}
           emailConfig={emailConfig}
-          sampleEmail={validCertificates[0].email}
+          sampleEmail={parseRecipientsDetailed(
+            validCertificates[0].email
+          ).valid.join(', ')}
           sampleFileName={validCertificates[0].fileName}
           sampleDownloadUrl={validCertificates[0].downloadUrl}
         />

--- a/components/modals/BulkEmailModal.tsx
+++ b/components/modals/BulkEmailModal.tsx
@@ -72,6 +72,9 @@ export function BulkEmailModal({
     (cert) => cert.email && parseRecipientsDetailed(cert.email).valid.length > 0
   );
   const skippedCount = certificates.length - validCertificates.length;
+  const partiallyInvalidCount = validCertificates.filter(
+    (cert) => parseRecipientsDetailed(cert.email).rejected.length > 0
+  ).length;
   
   const [status, setStatus] = useState<EmailStatus>({
     status: 'idle',
@@ -450,10 +453,17 @@ export function BulkEmailModal({
                   ⚠️ Skipping {skippedCount} certificate{skippedCount > 1 ? 's' : ''} without email addresses
                 </p>
               )}
+              {partiallyInvalidCount > 0 && (
+                <p className="text-xs text-amber-700 mb-2">
+                  ⚠️ Ignoring invalid addresses in {partiallyInvalidCount} mixed recipient {partiallyInvalidCount === 1 ? 'cell' : 'cells'}
+                </p>
+              )}
               <div className="max-h-32 overflow-y-auto">
                 <ul className="text-xs text-blue-700 space-y-1">
                   {validCertificates.slice(0, 5).map((cert, idx) => (
-                    <li key={idx}>• {cert.email}</li>
+                    <li key={idx}>
+                      • {parseRecipientsDetailed(cert.email).valid.join(', ')}
+                    </li>
                   ))}
                   {validCertificates.length > 5 && (
                     <li className="text-blue-600 italic">... and {validCertificates.length - 5} more</li>

--- a/components/modals/BulkEmailModal.tsx
+++ b/components/modals/BulkEmailModal.tsx
@@ -4,7 +4,7 @@ import { Progress } from '@/components/ui/progress';
 import { COLORS } from '@/utils/styles';
 import { EmailPreviewModal } from './EmailPreviewModal';
 import { buildLinkEmail, buildAttachmentEmail } from '@/lib/email-templates';
-import { isValidEmailValue } from '@/utils/email-validation';
+import { parseRecipientsDetailed } from '@/utils/email-validation';
 import {
   blobToBase64,
   createEmailSessionId,
@@ -69,7 +69,7 @@ export function BulkEmailModal({
 }: BulkEmailModalProps) {
   // Filter out certificates without email addresses
   const validCertificates = certificates.filter(
-    (cert) => cert.email && isValidEmailValue(cert.email)
+    (cert) => cert.email && parseRecipientsDetailed(cert.email).valid.length > 0
   );
   const skippedCount = certificates.length - validCertificates.length;
   

--- a/hooks/useTableData.ts
+++ b/hooks/useTableData.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import type { TableData } from "@/types/certificate";
-import { isValidEmailValue } from "@/utils/email-validation";
+import { parseRecipientsDetailed } from "@/utils/email-validation";
 
 export interface UseTableDataReturn {
   tableData: TableData[];
@@ -152,8 +152,8 @@ const detectEmailColumn = (headers: string[], data: TableData[]): string | null 
         .filter((val) => val && val.trim() !== "");
 
       if (columnValues.length > 0) {
-        const emailCount = columnValues.filter((val) =>
-          isValidEmailValue(val)
+        const emailCount = columnValues.filter(
+          (val) => parseRecipientsDetailed(val).valid.length > 0
         ).length;
 
         if (emailCount / columnValues.length >= 0.5) {

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -11,6 +11,9 @@ const MAX_BULK_EMAILS = 500;
 const BULK_ATTACHMENT_CONCURRENCY = 4;
 const DEFAULT_MAX_BULK_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 const HARD_MAX_BULK_ATTACHMENT_BYTES = 250 * 1024 * 1024;
+const ACTIVE_QUEUE_TTL_MS = 3600000;
+const PAUSED_QUEUE_TTL_MS = 24 * ACTIVE_QUEUE_TTL_MS;
+const MAX_PAUSED_ATTACHMENT_BYTES = HARD_MAX_BULK_ATTACHMENT_BYTES;
 
 function getMaxBulkAttachmentBytes(): number {
   const configured = Number.parseInt(process.env.MAX_BULK_EMAIL_ATTACHMENT_BYTES || '', 10);
@@ -392,25 +395,42 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
 // Store the interval ID so it can be cleared if needed
 let cleanupInterval: NodeJS.Timeout | null = null;
 
-export async function cleanupExpiredEmailQueues(now = Date.now()): Promise<void> {
-  const staleActiveTime = now - 3600000;
-  const stalePausedTime = now - 24 * 3600000;
-  const expiredKeys = Array.from(queueManagers.entries())
-    .filter(([, manager]) => {
-      const status = manager.getStatus().status;
-      const expirationTime = status === 'paused' ? stalePausedTime : staleActiveTime;
-      return manager.getLastActivity() < expirationTime;
-    })
-    .map(([key]) => key);
+function isQueueExpired(manager: EmailQueueManager, now: number): boolean {
+  const ttl = manager.getStatus().status === 'paused'
+    ? PAUSED_QUEUE_TTL_MS
+    : ACTIVE_QUEUE_TTL_MS;
+  return manager.getLastActivity() < now - ttl;
+}
 
-  await Promise.all(expiredKeys.map((key) =>
+export async function cleanupExpiredEmailQueues(now = Date.now()): Promise<void> {
+  const entries = Array.from(queueManagers.entries());
+  const expiredKeys = new Set(
+    entries.filter(([, manager]) => isQueueExpired(manager, now)).map(([key]) => key)
+  );
+  const pausedEntries = entries
+    .filter(([, manager]) => manager.getStatus().status === 'paused')
+    .sort(([, first], [, second]) =>
+      first.getLastActivity() - second.getLastActivity()
+    );
+  const pressureKeys = new Set<string>();
+  let pausedBytes = pausedEntries.reduce(
+    (total, [key]) => total + (queueAttachmentBytes.get(key) || 0),
+    0
+  );
+  for (const [key] of pausedEntries) {
+    if (pausedBytes <= MAX_PAUSED_ATTACHMENT_BYTES) break;
+    pressureKeys.add(key);
+    pausedBytes -= queueAttachmentBytes.get(key) || 0;
+  }
+  const cleanupKeys = new Set([...expiredKeys, ...pressureKeys]);
+
+  await Promise.all(Array.from(cleanupKeys).map((key) =>
     withQueueIngestionLock(key, async () => {
       const manager = queueManagers.get(key);
       if (!manager) return;
-      const expirationTime = manager.getStatus().status === 'paused'
-        ? stalePausedTime
-        : staleActiveTime;
-      if (manager.getLastActivity() >= expirationTime) return;
+      const isUnderPressure =
+        pressureKeys.has(key) && manager.getStatus().status === 'paused';
+      if (!isUnderPressure && !isQueueExpired(manager, now)) return;
       await manager.clear();
       queueManagers.delete(key);
       queueAttachmentBytes.delete(key);

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -393,15 +393,24 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
 let cleanupInterval: NodeJS.Timeout | null = null;
 
 export async function cleanupExpiredEmailQueues(now = Date.now()): Promise<void> {
-  const expirationTime = now - 3600000;
+  const staleActiveTime = now - 3600000;
+  const stalePausedTime = now - 24 * 3600000;
   const expiredKeys = Array.from(queueManagers.entries())
-    .filter(([, manager]) => manager.getLastActivity() < expirationTime)
+    .filter(([, manager]) => {
+      const status = manager.getStatus().status;
+      const expirationTime = status === 'paused' ? stalePausedTime : staleActiveTime;
+      return manager.getLastActivity() < expirationTime;
+    })
     .map(([key]) => key);
 
   await Promise.all(expiredKeys.map((key) =>
     withQueueIngestionLock(key, async () => {
       const manager = queueManagers.get(key);
-      if (!manager || manager.getLastActivity() >= expirationTime) return;
+      if (!manager) return;
+      const expirationTime = manager.getStatus().status === 'paused'
+        ? stalePausedTime
+        : staleActiveTime;
+      if (manager.getLastActivity() >= expirationTime) return;
       await manager.clear();
       queueManagers.delete(key);
       queueAttachmentBytes.delete(key);

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -140,6 +140,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     }
 
     const key = queueKey(userId, sessionId);
+    let successPayload: Record<string, unknown> | null = null;
     await withQueueIngestionLock(key, async () => {
       // Get or create queue manager for this session
       let queueManager = queueManagers.get(key);
@@ -278,14 +279,16 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
         queueManager.processQueue().catch(console.error);
       }
 
-      res.status(200).json({
+      successPayload = {
         success: true,
         queueLength: queueManager.getQueueLength(),
         status: queueManager.getStatus(),
         skippedCount // Number of emails skipped due to invalid addresses
-      });
+      };
     });
+    if (!successPayload) return;
     await enforcePausedAttachmentLimit();
+    res.status(200).json(successPayload);
     return;
   } catch (error) {
     if (error instanceof PdfSourceError) {
@@ -370,6 +373,7 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
     }
 
     const key = queueKey(userId, sessionId);
+    let actionSucceeded = false;
     await withQueueIngestionLock(key, async () => {
       const queueManager = queueManagers.get(key);
       if (!queueManager) {
@@ -394,11 +398,13 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
         return;
       }
 
-      res.status(200).json({ success: true });
+      actionSucceeded = true;
     });
+    if (!actionSucceeded) return;
     if (action === 'pause') {
       await enforcePausedAttachmentLimit();
     }
+    res.status(200).json({ success: true });
     return;
   } catch (error) {
     console.error('Queue control error:', error);

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -13,12 +13,24 @@ const DEFAULT_MAX_BULK_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 const HARD_MAX_BULK_ATTACHMENT_BYTES = 250 * 1024 * 1024;
 const ACTIVE_QUEUE_TTL_MS = 3600000;
 const PAUSED_QUEUE_TTL_MS = 24 * ACTIVE_QUEUE_TTL_MS;
-const MAX_PAUSED_ATTACHMENT_BYTES = HARD_MAX_BULK_ATTACHMENT_BYTES;
+const DEFAULT_MAX_PAUSED_ATTACHMENT_BYTES = HARD_MAX_BULK_ATTACHMENT_BYTES;
+const PAUSED_PRESSURE_LOCK = '__global_paused_queue_pressure__';
 
 function getMaxBulkAttachmentBytes(): number {
   const configured = Number.parseInt(process.env.MAX_BULK_EMAIL_ATTACHMENT_BYTES || '', 10);
   if (!Number.isSafeInteger(configured) || configured <= 0) {
     return DEFAULT_MAX_BULK_ATTACHMENT_BYTES;
+  }
+  return Math.min(configured, HARD_MAX_BULK_ATTACHMENT_BYTES);
+}
+
+function getMaxPausedAttachmentBytes(): number {
+  const configured = Number.parseInt(
+    process.env.MAX_PAUSED_EMAIL_ATTACHMENT_BYTES || '',
+    10
+  );
+  if (!Number.isSafeInteger(configured) || configured <= 0) {
+    return DEFAULT_MAX_PAUSED_ATTACHMENT_BYTES;
   }
   return Math.min(configured, HARD_MAX_BULK_ATTACHMENT_BYTES);
 }
@@ -273,6 +285,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
         skippedCount // Number of emails skipped due to invalid addresses
       });
     });
+    await enforcePausedAttachmentLimit();
     return;
   } catch (error) {
     if (error instanceof PdfSourceError) {
@@ -383,6 +396,9 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
 
       res.status(200).json({ success: true });
     });
+    if (action === 'pause') {
+      await enforcePausedAttachmentLimit();
+    }
     return;
   } catch (error) {
     console.error('Queue control error:', error);
@@ -402,40 +418,49 @@ function isQueueExpired(manager: EmailQueueManager, now: number): boolean {
   return manager.getLastActivity() < now - ttl;
 }
 
+async function enforcePausedAttachmentLimit(): Promise<void> {
+  await withQueueIngestionLock(PAUSED_PRESSURE_LOCK, async () => {
+    const pausedEntries = Array.from(queueManagers.entries())
+      .filter(([, manager]) => manager.getStatus().status === 'paused')
+      .sort(([, first], [, second]) =>
+        first.getLastActivity() - second.getLastActivity()
+      );
+    let pausedBytes = pausedEntries.reduce(
+      (total, [key]) => total + (queueAttachmentBytes.get(key) || 0),
+      0
+    );
+
+    for (const [key] of pausedEntries) {
+      if (pausedBytes <= getMaxPausedAttachmentBytes()) break;
+      await withQueueIngestionLock(key, async () => {
+        const manager = queueManagers.get(key);
+        if (!manager || manager.getStatus().status !== 'paused') return;
+        const retainedBytes = queueAttachmentBytes.get(key) || 0;
+        await manager.clear();
+        queueManagers.delete(key);
+        queueAttachmentBytes.delete(key);
+        pausedBytes -= retainedBytes;
+      });
+    }
+  });
+}
+
 export async function cleanupExpiredEmailQueues(now = Date.now()): Promise<void> {
   const entries = Array.from(queueManagers.entries());
   const expiredKeys = new Set(
     entries.filter(([, manager]) => isQueueExpired(manager, now)).map(([key]) => key)
   );
-  const pausedEntries = entries
-    .filter(([, manager]) => manager.getStatus().status === 'paused')
-    .sort(([, first], [, second]) =>
-      first.getLastActivity() - second.getLastActivity()
-    );
-  const pressureKeys = new Set<string>();
-  let pausedBytes = pausedEntries.reduce(
-    (total, [key]) => total + (queueAttachmentBytes.get(key) || 0),
-    0
-  );
-  for (const [key] of pausedEntries) {
-    if (pausedBytes <= MAX_PAUSED_ATTACHMENT_BYTES) break;
-    pressureKeys.add(key);
-    pausedBytes -= queueAttachmentBytes.get(key) || 0;
-  }
-  const cleanupKeys = new Set([...expiredKeys, ...pressureKeys]);
-
-  await Promise.all(Array.from(cleanupKeys).map((key) =>
+  await Promise.all(Array.from(expiredKeys).map((key) =>
     withQueueIngestionLock(key, async () => {
       const manager = queueManagers.get(key);
       if (!manager) return;
-      const isUnderPressure =
-        pressureKeys.has(key) && manager.getStatus().status === 'paused';
-      if (!isUnderPressure && !isQueueExpired(manager, now)) return;
+      if (!isQueueExpired(manager, now)) return;
       await manager.clear();
       queueManagers.delete(key);
       queueAttachmentBytes.delete(key);
     })
   ));
+  await enforcePausedAttachmentLimit();
 }
 
 // Only set up the interval if it hasn't been set up already

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -287,7 +287,9 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
       };
     });
     if (!successPayload) return;
-    await enforcePausedAttachmentLimit();
+    await enforcePausedAttachmentLimit().catch((error) => {
+      console.error('Paused queue pressure cleanup failed:', error);
+    });
     res.status(200).json(successPayload);
     return;
   } catch (error) {
@@ -402,7 +404,9 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
     });
     if (!actionSucceeded) return;
     if (action === 'pause') {
-      await enforcePausedAttachmentLimit();
+      await enforcePausedAttachmentLimit().catch((error) => {
+        console.error('Paused queue pressure cleanup failed:', error);
+      });
     }
     res.status(200).json({ success: true });
     return;
@@ -431,21 +435,21 @@ async function enforcePausedAttachmentLimit(): Promise<void> {
       .sort(([, first], [, second]) =>
         first.getLastActivity() - second.getLastActivity()
       );
-    let pausedBytes = pausedEntries.reduce(
-      (total, [key]) => total + (queueAttachmentBytes.get(key) || 0),
-      0
-    );
-
     for (const [key] of pausedEntries) {
+      const pausedBytes = Array.from(queueManagers.entries()).reduce(
+        (total, [queueKey, manager]) =>
+          manager.getStatus().status === 'paused'
+            ? total + (queueAttachmentBytes.get(queueKey) || 0)
+            : total,
+        0
+      );
       if (pausedBytes <= getMaxPausedAttachmentBytes()) break;
       await withQueueIngestionLock(key, async () => {
         const manager = queueManagers.get(key);
         if (!manager || manager.getStatus().status !== 'paused') return;
-        const retainedBytes = queueAttachmentBytes.get(key) || 0;
         await manager.clear();
         queueManagers.delete(key);
         queueAttachmentBytes.delete(key);
-        pausedBytes -= retainedBytes;
       });
     }
   });


### PR DESCRIPTION
## Summary

- preserve valid recipients when an email cell also contains an invalid address
- retain paused bulk-email queues for 24 hours while still expiring abandoned active queues after one hour
- add regressions for mixed recipient cells and paused queue retention

Follow-up to review comments that landed concurrently with the merge of #41.

## Verification

- focused Jest suites (14 passed)
- `npm run build`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->