### PR TITLE
security: move generated files to private storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,10 @@ node_modules
 README.md
 .env*.local
 .env
+data
+storage
+prisma/*.db
+prisma/*.db-*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,11 @@ NEXT_PUBLIC_PROJECT_SERVER_PERSISTENCE=false
 # Choose one: 'local' (default), 'cloudflare-r2', or 'amazon-s3'
 STORAGE_PROVIDER=local
 
+# Private local storage root (defaults to ./storage, or /app/storage in production)
+# LOCAL_STORAGE_DIR=/app/storage
+# HMAC secret for expiring local download links (falls back to NEXTAUTH_SECRET)
+# FILE_URL_SIGNING_SECRET=replace-with-a-long-random-secret
+
 # --- Cloudflare R2 (if STORAGE_PROVIDER=cloudflare-r2) ---
 # Get these from Cloudflare dashboard > R2
 # R2_ACCOUNT_ID=your_account_id_here
@@ -53,7 +58,7 @@ STORAGE_PROVIDER=local
 # R2_SECRET_ACCESS_KEY=your_secret_key_here
 # R2_BUCKET_NAME=your-bucket-name
 # R2_ENDPOINT=https://your_account_id.r2.cloudflarestorage.com
-# R2_PUBLIC_URL=https://certs.yourdomain.com  # Optional custom domain
+# R2_PUBLIC_URL=https://certs.yourdomain.com  # Optional trusted origin; user files still use signed URLs
 
 # --- Amazon S3 (if STORAGE_PROVIDER=amazon-s3) ---
 # Create IAM user with S3 permissions
@@ -61,7 +66,7 @@ STORAGE_PROVIDER=local
 # S3_SECRET_ACCESS_KEY=xxxxx
 # S3_BUCKET_NAME=your-bucket-name
 # S3_REGION=us-east-1
-# S3_CLOUDFRONT_URL=https://d1234567890.cloudfront.net  # Optional CDN
+# S3_CLOUDFRONT_URL=https://d1234567890.cloudfront.net  # Optional trusted origin; user files still use signed URLs
 
 # Server-side PDF retrieval limits (downloads, ZIPs, and email attachments)
 # MAX_PDF_SOURCE_SIZE_BYTES=26214400  # 25MB per PDF

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ dev.log
 tmp/
 public/generated/
 public/temp_images/
+/storage/
 **/.claude/settings.local.json
 
 # Docker volume data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ npm run cleanup:old:dry # Preview what would be deleted without actually deletin
 - **Next.js Config**: Uses `next.config.js` (CommonJS format)
 - **Coordinate System**: PDF uses bottom-left origin (0,0), UI uses top-left - conversion in API
 - **File Storage**: 
-  - Development: `public/` directory
-  - Production: Docker volumes + cloud storage (R2/S3)
+  - Development: private `storage/` directory
+  - Production: private Docker volumes + cloud storage (R2/S3)
 - **Email**: Multi-provider (Resend/SES) with auto-detection
 - **Cloud Storage**: Multi-provider (Cloudflare R2/Amazon S3) with lifecycle management
 - **Table Virtualization**: Uses react-window for datasets > 100 rows
@@ -309,7 +309,7 @@ npm run cleanup:old:dry # Preview what would be deleted without actually deletin
 ### Manual Cleanup
 ```bash
 # Local Development
-rm -rf public/temp_images/* public/generated/*
+rm -rf storage/temp_images/* storage/generated/*
 
 # Docker Production
 rm -rf ./data/temp_images/* ./data/generated/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,22 +39,24 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/next.config.js ./next.config.js
+# Copy the startup storage migration invoked by npm's prestart hook
+COPY --from=builder /app/scripts/migrate-private-storage.js ./scripts/migrate-private-storage.js
 # Copy Prisma schema and migrations
 COPY --from=builder /app/prisma ./prisma
 # Copy entrypoint script
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
 
-# Create required directories for file uploads and generated PDFs
-RUN mkdir -p /app/public/temp_images /app/public/generated /app/public/template_images
+# Create private persisted directories for uploads and generated PDFs
+RUN mkdir -p /app/storage/temp_images /app/storage/generated /app/storage/template_images
 # Create directory for SQLite database
 RUN mkdir -p /app/prisma
 # Create temp directory for formidable uploads with proper permissions
 RUN mkdir -p /app/tmp/uploads
 # Ensure proper permissions for the directories
 RUN chown -R nextjs:nodejs /app
-# Make sure the public directories are writable
+# Static public assets are read-only; persisted user files live under /app/storage
 RUN chmod -R 755 /app/public
-RUN chmod -R 775 /app/public/temp_images /app/public/generated /app/public/template_images
+RUN chmod -R 775 /app/storage
 # Make temp directory writable for formidable
 RUN chmod -R 777 /app/tmp/uploads
 # Make prisma directory writable for database

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ GOOGLE_CLIENT_SECRET=...
 ADMIN_EMAILS=you@example.com, teammate@example.com
 ```
 
+## Private file storage
+
+Persisted uploads and generated certificates live under `storage/` (or `LOCAL_STORAGE_DIR`), never under Next.js' `public/` directory. `npm start` and `npm run dev` automatically migrate legacy local files; `npm run migrate:storage` is also available for one-shot migrations. Docker keeps the existing `./data/*` host directories and remounts them at `/app/storage/*`, so no host-side copy is required.
+
+Generated download links are signed capabilities that expire after 90 days. Set `NEXTAUTH_URL` to the public application origin so emailed links are absolute, and set `FILE_URL_SIGNING_SECRET` (or a strong `NEXTAUTH_SECRET`) consistently across instances. Previously emailed unsigned `/generated/...` links are intentionally invalidated because their guessable paths cannot be converted into secure capabilities retroactively.
+
 ## Dev Mode Features
 
 In Dev Mode, you have access to additional monitoring and cleanup tools:
@@ -195,7 +201,7 @@ npm run cleanup:old:dry # Preview what would be deleted without actually deletin
 ### Manual Cleanup
 ```bash
 # Local Development
-rm -rf public/temp_images/* public/generated/*
+rm -rf storage/temp_images/* storage/generated/*
 
 # Docker Production
 rm -rf ./data/temp_images/* ./data/generated/*

--- a/__tests__/api/admin-files.test.ts
+++ b/__tests__/api/admin-files.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { once } from 'events';
+import httpMocks from 'node-mocks-http';
+import { adminFilesHandler } from '@/pages/api/admin/files/[...path]';
+
+describe('admin private file delivery', () => {
+  let storageDir: string;
+
+  beforeEach(() => {
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-admin-storage-'));
+    process.env.LOCAL_STORAGE_DIR = storageDir;
+    fs.mkdirSync(path.join(storageDir, 'generated', 'u_1'), { recursive: true });
+    fs.writeFileSync(path.join(storageDir, 'generated', 'u_1', 'file.pdf'), '%PDF-1.4\ntest');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.LOCAL_STORAGE_DIR;
+    fs.rmSync(storageDir, { recursive: true, force: true });
+  });
+
+  it('streams a private stored file without public caching', async () => {
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: { path: ['generated', 'u_1', 'file.pdf'] },
+    });
+    const res = httpMocks.createResponse();
+    const streamSpy = jest.spyOn(fs, 'createReadStream');
+
+    await adminFilesHandler(req as any, res as any);
+    const stream = streamSpy.mock.results[0]?.value as fs.ReadStream | undefined;
+    if (stream && !stream.closed) await once(stream, 'close');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader('Cache-Control')).toBe('private, no-store');
+    expect(streamSpy).toHaveBeenCalledWith(expect.stringContaining('storage-'));
+  });
+
+  it('rejects traversal and symlinks outside private storage', async () => {
+    const traversalReq = httpMocks.createRequest({
+      method: 'GET',
+      query: { path: ['generated', '..', '..', 'secret.pdf'] },
+    });
+    const traversalRes = httpMocks.createResponse();
+    await adminFilesHandler(traversalReq as any, traversalRes as any);
+    expect(traversalRes.statusCode).toBe(403);
+
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-admin-outside-'));
+    const outsideFile = path.join(outsideDir, 'secret.pdf');
+    fs.writeFileSync(outsideFile, '%PDF-1.4\nsecret');
+    fs.symlinkSync(outsideFile, path.join(storageDir, 'generated', 'u_1', 'link.pdf'));
+    const linkReq = httpMocks.createRequest({
+      method: 'GET',
+      query: { path: ['generated', 'u_1', 'link.pdf'] },
+    });
+    const linkRes = httpMocks.createResponse();
+    await adminFilesHandler(linkReq as any, linkRes as any);
+    expect(linkRes.statusCode).toBe(403);
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+});

--- a/__tests__/api/bulk-retention-concurrency.test.ts
+++ b/__tests__/api/bulk-retention-concurrency.test.ts
@@ -1,0 +1,45 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/storage/mark-generated', () => ({
+  markGeneratedFileAsEmailed: jest.fn(),
+}));
+
+import {
+  cleanupEmailQueueInterval,
+  markGeneratedRetentionInBatches,
+} from '@/pages/api/send-bulk-email';
+import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
+
+describe('bulk retention metadata updates', () => {
+  afterAll(() => cleanupEmailQueueInterval());
+
+  it('limits concurrent cloud object rewrites', async () => {
+    let active = 0;
+    let peak = 0;
+    const releases: Array<() => void> = [];
+    (markGeneratedFileAsEmailed as jest.Mock).mockImplementation(() => {
+      active += 1;
+      peak = Math.max(peak, active);
+      return new Promise<void>(resolve => releases.push(() => {
+        active -= 1;
+        resolve();
+      }));
+    });
+
+    const pending = markGeneratedRetentionInBatches(
+      Array.from({ length: 10 }, (_, index) => `/file-${index}.pdf`),
+      'u1',
+    );
+
+    await new Promise(resolve => setImmediate(resolve));
+    expect(active).toBe(4);
+    while (releases.length > 0) {
+      releases.splice(0, 4).forEach(release => release());
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    await pending;
+
+    expect(peak).toBe(4);
+    expect(markGeneratedFileAsEmailed).toHaveBeenCalledTimes(10);
+  });
+});

--- a/__tests__/api/files-auth.test.ts
+++ b/__tests__/api/files-auth.test.ts
@@ -1,7 +1,15 @@
 jest.mock('@/pages/api/auth/[...nextauth]', () => ({ __esModule: true, authOptions: {}, default: jest.fn() }));
 jest.mock('@/lib/auth/requireAuth', () => ({ requireAuth: jest.fn(async () => ({ user: { id: 'u1' } })) }));
+jest.mock('@/lib/storage-config', () => ({
+  __esModule: true,
+  default: { isR2Enabled: true, isS3Enabled: false },
+}));
+jest.mock('@/lib/r2-client', () => ({ getPublicUrl: jest.fn(async () => 'https://bucket.example/file') }));
 import handlerTemp from '@/pages/api/files/temp_images/[...path]';
 import handlerGen from '@/pages/api/files/generated/[...path]';
+import handlerTempFlat from '@/pages/api/files/temp_images/[filename]';
+import handlerGenFlat from '@/pages/api/files/generated/[filename]';
+import handlerTemplate from '@/pages/api/files/template_images/[filename]';
 import httpMocks from 'node-mocks-http';
 
 jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }));
@@ -29,6 +37,46 @@ describe('file serving auth', () => {
     expect(res.statusCode).toBe(401);
   });
 
+  it('rejects another user generated-file namespace', async () => {
+    requireAuth.mockResolvedValue({ user: { id: 'u1' } });
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: { path: ['u_other', 'session', 'foo.pdf'] },
+    });
+    const res = httpMocks.createResponse();
+
+    await handlerGen(req as any, res as any);
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('does not serve unscoped legacy generated filenames', async () => {
+    requireAuth.mockResolvedValue({ user: { id: 'u1' } });
+    const req = httpMocks.createRequest({ method: 'GET', query: { filename: 'foo.pdf' } });
+    const res = httpMocks.createResponse();
+
+    await handlerGenFlat(req as any, res as any);
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it.each([
+    ['flat generated files', handlerGenFlat, { filename: 'foo.pdf' }],
+    ['flat temporary images', handlerTempFlat, { filename: 'foo.jpg' }],
+    ['template images', handlerTemplate, { filename: 'foo.jpg' }],
+  ])('requires auth for %s', async (_name, handler, query) => {
+    requireAuth.mockImplementation(async (_req: any, res: any) => {
+      res.status(401).json({ message: 'Unauthorized' });
+      return null;
+    });
+    const req = httpMocks.createRequest({ method: 'GET', query });
+    const res = httpMocks.createResponse();
+
+    await handler(req as any, res as any);
+
+    expect(res.statusCode).toBe(401);
+  });
+
   it('enforces user prefix for temp images', async () => {
     requireAuth.mockResolvedValue({ user: { id: 'u1' } });
     // Wrong user prefix
@@ -38,7 +86,7 @@ describe('file serving auth', () => {
     expect(res.statusCode).toBe(403);
   });
 
-  it('serves temp image for correct user', async () => {
+  it('serves the same-origin local temp image in cloud mode when available', async () => {
     const fsMod: any = require('fs');
     if (fsMod.default?.existsSync) fsMod.default.existsSync.mockReturnValue(true);
     if (fsMod.existsSync) fsMod.existsSync.mockReturnValue(true);
@@ -47,6 +95,20 @@ describe('file serving auth', () => {
     const res = httpMocks.createResponse();
     await handlerTemp(req as any, res as any);
     expect(res.statusCode).toBe(200);
+    expect(res.getHeader('Location')).toBeUndefined();
     expect(res._getBuffer()).toBeInstanceOf(Buffer);
+  });
+
+  it('rejects traversal after a valid user prefix', async () => {
+    requireAuth.mockResolvedValue({ user: { id: 'u1' } });
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: { path: ['u_u1', '..', '..', 'temp_images-elsewhere', 'img.jpg'] },
+    });
+    const res = httpMocks.createResponse();
+
+    await handlerTemp(req as any, res as any);
+
+    expect(res.statusCode).toBe(403);
   });
 });

--- a/__tests__/api/mark-emailed-local.test.ts
+++ b/__tests__/api/mark-emailed-local.test.ts
@@ -1,0 +1,56 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(async () => ({ user: { id: 'user' } })),
+}));
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import httpMocks from 'node-mocks-http';
+import handler from '@/pages/api/mark-emailed';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+
+describe('local mark-emailed API', () => {
+  let storageDir: string;
+
+  beforeEach(() => {
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-mark-api-'));
+    process.env.STORAGE_PROVIDER = 'local';
+    process.env.LOCAL_STORAGE_DIR = storageDir;
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.STORAGE_PROVIDER;
+    delete process.env.LOCAL_STORAGE_DIR;
+    delete process.env.FILE_URL_SIGNING_SECRET;
+    fs.rmSync(storageDir, { recursive: true, force: true });
+  });
+
+  it('creates the local 90-day retention marker', async () => {
+    const relativePath = 'u_user/session/certificate.pdf';
+    const filePath = path.join(storageDir, 'generated', relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '%PDF-1.4\ntest');
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: { fileUrl: createSignedGeneratedFileUrl(relativePath) },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(fs.existsSync(`${filePath}.retention-90d`)).toBe(true);
+  });
+
+  it('still validates the request in local mode', async () => {
+    const req = httpMocks.createRequest({ method: 'POST', body: {} });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/__tests__/api/signed-cloud-download.test.ts
+++ b/__tests__/api/signed-cloud-download.test.ts
@@ -1,0 +1,42 @@
+/** @jest-environment node */
+
+import httpMocks from 'node-mocks-http';
+import handler from '@/pages/api/files/download';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+import { getPublicUrl } from '@/lib/r2-client';
+
+jest.mock('@/lib/storage-config', () => ({
+  __esModule: true,
+  default: { isR2Enabled: true, isS3Enabled: false },
+}));
+jest.mock('@/lib/r2-client', () => ({
+  getPublicUrl: jest.fn(async () => 'https://r2.example/signed-provider-url'),
+}));
+jest.mock('@/lib/s3-client', () => ({
+  getS3SignedUrl: jest.fn(),
+}));
+
+describe('signed cloud download', () => {
+  beforeEach(() => {
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.FILE_URL_SIGNING_SECRET;
+  });
+
+  it('turns a stable app capability into a fresh provider-signed redirect', async () => {
+    const signedUrl = new URL(
+      createSignedGeneratedFileUrl('u_user/session/certificate.pdf'),
+      'https://certificates.example',
+    );
+    const req = httpMocks.createRequest({ method: 'GET', query: Object.fromEntries(signedUrl.searchParams) });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(302);
+    expect(res._getRedirectUrl()).toBe('https://r2.example/signed-provider-url');
+    expect(getPublicUrl).toHaveBeenCalledWith('generated/u_user/session/certificate.pdf');
+  });
+});

--- a/__tests__/api/signed-file-download.test.ts
+++ b/__tests__/api/signed-file-download.test.ts
@@ -1,0 +1,115 @@
+/** @jest-environment node */
+
+import httpMocks from 'node-mocks-http';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { once } from 'events';
+import handler from '@/pages/api/files/download';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+
+describe('signed generated file download', () => {
+  let storageDir: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-storage-'));
+    process.env.LOCAL_STORAGE_DIR = storageDir;
+    fs.mkdirSync(path.join(storageDir, 'generated', 'session'), { recursive: true });
+    fs.writeFileSync(
+      path.join(storageDir, 'generated', 'session', 'certificate.pdf'),
+      Buffer.from('%PDF-1.4\ntest'),
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.FILE_URL_SIGNING_SECRET;
+    delete process.env.LOCAL_STORAGE_DIR;
+    delete process.env.MAX_PDF_SOURCE_SIZE_BYTES;
+    fs.rmSync(storageDir, { recursive: true, force: true });
+  });
+
+  it('serves a valid signed PDF without public caching', async () => {
+    const signedUrl = new URL(
+      createSignedGeneratedFileUrl('session/certificate.pdf'),
+      'https://certificates.example',
+    );
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: Object.fromEntries(signedUrl.searchParams),
+    });
+    const res = httpMocks.createResponse();
+    const streamSpy = jest.spyOn(fs, 'createReadStream');
+
+    await handler(req, res);
+    const readStream = streamSpy.mock.results[0]?.value;
+    if (readStream && !(readStream as fs.ReadStream).closed) {
+      await once(readStream as fs.ReadStream, 'close');
+    }
+
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader('Cache-Control')).toBe('private, no-store');
+    expect(res.getHeader('Content-Type')).toBe('application/pdf');
+    expect(streamSpy).toHaveBeenCalledWith(expect.stringContaining('generated/session/certificate.pdf'));
+  });
+
+  it('rejects a tampered path before reading the filesystem', async () => {
+    const signedUrl = new URL(
+      createSignedGeneratedFileUrl('session/certificate.pdf'),
+      'https://certificates.example',
+    );
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      query: {
+        path: 'session/other.pdf',
+        expires: signedUrl.searchParams.get('expires'),
+        signature: signedUrl.searchParams.get('signature'),
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('streams large user downloads independently of the PDF ingestion limit', async () => {
+    process.env.MAX_PDF_SOURCE_SIZE_BYTES = '4';
+    const signedUrl = new URL(
+      createSignedGeneratedFileUrl('session/certificate.pdf'),
+      'https://certificates.example',
+    );
+    const req = httpMocks.createRequest({ method: 'GET', query: Object.fromEntries(signedUrl.searchParams) });
+    const res = httpMocks.createResponse();
+
+    const streamSpy = jest.spyOn(fs, 'createReadStream');
+
+    await handler(req, res);
+    const readStream = streamSpy.mock.results[0]?.value;
+    if (readStream && !(readStream as fs.ReadStream).closed) {
+      await once(readStream as fs.ReadStream, 'close');
+    }
+
+    expect(res.statusCode).toBe(200);
+    expect(streamSpy).toHaveBeenCalled();
+  });
+
+  it('rejects a symlink that escapes private storage', async () => {
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-outside-'));
+    const outsideFile = path.join(outsideDir, 'outside.pdf');
+    fs.writeFileSync(outsideFile, '%PDF-1.4\noutside');
+    fs.symlinkSync(outsideFile, path.join(storageDir, 'generated', 'session', 'link.pdf'));
+    const signedUrl = new URL(
+      createSignedGeneratedFileUrl('session/link.pdf'),
+      'https://certificates.example',
+    );
+    const req = httpMocks.createRequest({ method: 'GET', query: Object.fromEntries(signedUrl.searchParams) });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+});

--- a/__tests__/lib/cleanup-scripts.test.ts
+++ b/__tests__/lib/cleanup-scripts.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+describe('private storage cleanup scripts', () => {
+  let storageDir: string;
+
+  beforeEach(() => {
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-cleanup-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(storageDir, { recursive: true, force: true });
+  });
+
+  it('removes expired bulk files but retains 8-day individual certificates', () => {
+    const generatedDir = path.join(storageDir, 'generated', 'u_user', 'session');
+    const individualDir = path.join(storageDir, 'generated', 'u_user', 'individual_123');
+    fs.mkdirSync(generatedDir, { recursive: true });
+    fs.mkdirSync(individualDir, { recursive: true });
+    const expired = path.join(generatedDir, 'certificates_old.pdf');
+    const individual = path.join(individualDir, 'certificate.pdf');
+    fs.writeFileSync(expired, '%PDF-1.4\nold');
+    fs.writeFileSync(individual, '%PDF-1.4\nindividual');
+    const old = new Date(Date.now() - 9 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(expired, old, old);
+    fs.utimesSync(individual, old, old);
+
+    const result = spawnSync(process.execPath, ['scripts/cleanup-old-files.js'], {
+      cwd: process.cwd(),
+      env: { ...process.env, LOCAL_STORAGE_DIR: storageDir },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(expired)).toBe(false);
+    expect(fs.existsSync(individual)).toBe(true);
+  });
+
+  it('retains an emailed 8-day bulk file using its local retention marker', () => {
+    const generatedDir = path.join(storageDir, 'generated', 'u_user');
+    fs.mkdirSync(generatedDir, { recursive: true });
+    const emailed = path.join(generatedDir, 'certificates_emailed.pdf');
+    fs.writeFileSync(emailed, '%PDF-1.4\nemailed');
+    fs.writeFileSync(`${emailed}.retention-90d`, 'emailed');
+    const old = new Date(Date.now() - 9 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(emailed, old, old);
+
+    const result = spawnSync(process.execPath, ['scripts/cleanup-old-files.js'], {
+      cwd: process.cwd(),
+      env: { ...process.env, LOCAL_STORAGE_DIR: storageDir },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(emailed)).toBe(true);
+  });
+
+  it('does not follow directory symlinks outside the cleanup root', () => {
+    const generatedDir = path.join(storageDir, 'generated');
+    const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-cleanup-outside-'));
+    fs.mkdirSync(generatedDir, { recursive: true });
+    const outsideFile = path.join(outsideDir, 'certificates_old.pdf');
+    fs.writeFileSync(outsideFile, '%PDF-1.4\nkeep');
+    const old = new Date(Date.now() - 9 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(outsideFile, old, old);
+    fs.symlinkSync(outsideDir, path.join(generatedDir, 'u_attacker'));
+
+    const result = spawnSync(process.execPath, ['scripts/cleanup-old-files.js'], {
+      cwd: process.cwd(),
+      env: { ...process.env, LOCAL_STORAGE_DIR: storageDir },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outsideFile)).toBe(true);
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+});

--- a/__tests__/lib/mark-generated.test.ts
+++ b/__tests__/lib/mark-generated.test.ts
@@ -1,0 +1,59 @@
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
+import { markAsEmailed } from '@/lib/r2-client';
+
+jest.mock('@/lib/r2-client', () => ({
+  isR2Configured: jest.fn(() => true),
+  markAsEmailed: jest.fn(async () => undefined),
+}));
+jest.mock('@/lib/s3-client', () => ({
+  isS3Configured: jest.fn(() => false),
+  markAsEmailedS3: jest.fn(async () => undefined),
+}));
+
+describe('generated file retention ownership', () => {
+  beforeEach(() => {
+    process.env.STORAGE_PROVIDER = 'cloudflare-r2';
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.STORAGE_PROVIDER;
+    delete process.env.FILE_URL_SIGNING_SECRET;
+  });
+
+  it('persists a 90-day retention marker for local emailed files', async () => {
+    const storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-mark-local-'));
+    process.env.STORAGE_PROVIDER = 'local';
+    process.env.LOCAL_STORAGE_DIR = storageDir;
+    const relativePath = 'u_user/session/certificate.pdf';
+    const filePath = path.join(storageDir, 'generated', relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '%PDF-1.4\ntest');
+
+    await markGeneratedFileAsEmailed(createSignedGeneratedFileUrl(relativePath), 'user');
+
+    expect(fs.existsSync(`${filePath}.retention-90d`)).toBe(true);
+    fs.rmSync(storageDir, { recursive: true, force: true });
+    delete process.env.LOCAL_STORAGE_DIR;
+  });
+
+  it('marks the verified user-scoped object key', async () => {
+    const url = createSignedGeneratedFileUrl('u_user/session/certificate.pdf');
+
+    await markGeneratedFileAsEmailed(url, 'user');
+
+    expect(markAsEmailed).toHaveBeenCalledWith('generated/u_user/session/certificate.pdf');
+  });
+
+  it('rejects a capability owned by another user', async () => {
+    const url = createSignedGeneratedFileUrl('u_victim/session/certificate.pdf');
+
+    await expect(markGeneratedFileAsEmailed(url, 'attacker')).rejects.toMatchObject({ statusCode: 403 });
+    expect(markAsEmailed).not.toHaveBeenCalled();
+  });
+});
+import fs from 'fs';
+import os from 'os';
+import path from 'path';

--- a/__tests__/lib/private-file-access.test.ts
+++ b/__tests__/lib/private-file-access.test.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import {
+  getAuthorizedTemplateCandidates,
+  PrivateFileAccessError,
+} from '@/lib/security/private-file-access';
+
+describe('private template access', () => {
+  it('confines templates to the current user namespace', () => {
+    expect(getAuthorizedTemplateCandidates('u_user-1/template.pdf', 'user-1'))
+      .toEqual(expect.arrayContaining([
+        expect.stringContaining(path.join('temp_images', 'u_user-1', 'template.pdf')),
+      ]));
+    expect(() => getAuthorizedTemplateCandidates('u_victim/template.pdf', 'attacker'))
+      .toThrow(PrivateFileAccessError);
+    expect(() => getAuthorizedTemplateCandidates('u_user-1/../../secret.pdf', 'user-1'))
+      .toThrow(PrivateFileAccessError);
+    expect(() => getAuthorizedTemplateCandidates('u_user-1/../u_victim/secret.pdf', 'user-1'))
+      .toThrow(PrivateFileAccessError);
+  });
+
+  it('allows only the bundled development template outside a user namespace', () => {
+    expect(getAuthorizedTemplateCandidates('dev-mode-template.pdf', 'user-1')[0])
+      .toContain(path.join('public', 'template_images', 'dev-mode-template.pdf'));
+    expect(() => getAuthorizedTemplateCandidates('other-template.pdf', 'user-1'))
+      .toThrow(PrivateFileAccessError);
+  });
+});

--- a/__tests__/lib/private-storage-migration.test.ts
+++ b/__tests__/lib/private-storage-migration.test.ts
@@ -1,0 +1,42 @@
+/** @jest-environment node */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const { migrateDirectory } = require(path.join(process.cwd(), 'scripts', 'migrate-private-storage.js'));
+
+describe('private storage migration', () => {
+  it('moves legacy persisted entries without overwriting existing private data', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-migration-'));
+    const source = path.join(root, 'public', 'generated');
+    const destination = path.join(root, 'storage', 'generated');
+    fs.mkdirSync(source, { recursive: true });
+    fs.mkdirSync(destination, { recursive: true });
+    fs.writeFileSync(path.join(source, 'legacy.pdf'), 'legacy');
+    fs.writeFileSync(path.join(source, 'existing.pdf'), 'old');
+    fs.writeFileSync(path.join(destination, 'existing.pdf'), 'new');
+
+    expect(migrateDirectory(source, destination, 'generated')).toBe(2);
+    expect(fs.readFileSync(path.join(destination, 'legacy.pdf'), 'utf8')).toBe('legacy');
+    expect(fs.readFileSync(path.join(destination, 'existing.pdf'), 'utf8')).toBe('new');
+    expect(fs.existsSync(path.join(source, 'existing.pdf'))).toBe(false);
+    expect(fs.readFileSync(path.join(destination, 'existing.pdf.legacy-conflict'), 'utf8')).toBe('old');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('recursively merges colliding user directories without leaving public files', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-migration-'));
+    const source = path.join(root, 'public', 'temp_images');
+    const destination = path.join(root, 'storage', 'temp_images');
+    fs.mkdirSync(path.join(source, 'u_1'), { recursive: true });
+    fs.mkdirSync(path.join(destination, 'u_1'), { recursive: true });
+    fs.writeFileSync(path.join(source, 'u_1', 'legacy.jpg'), 'legacy');
+    fs.writeFileSync(path.join(destination, 'u_1', 'private.jpg'), 'private');
+
+    expect(migrateDirectory(source, destination, 'temp_images')).toBe(1);
+    expect(fs.readFileSync(path.join(destination, 'u_1', 'legacy.jpg'), 'utf8')).toBe('legacy');
+    expect(fs.existsSync(path.join(source, 'u_1'))).toBe(false);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});

--- a/__tests__/lib/signed-generated-url.test.ts
+++ b/__tests__/lib/signed-generated-url.test.ts
@@ -1,0 +1,67 @@
+import {
+  createSignedGeneratedFileUrl,
+  normalizeGeneratedPdfPath,
+  SignedFileUrlError,
+  verifySignedGeneratedFileUrl,
+} from '@/lib/security/signed-generated-url';
+
+describe('signed generated file URLs', () => {
+  beforeEach(() => {
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+  });
+
+  afterEach(() => {
+    delete process.env.FILE_URL_SIGNING_SECRET;
+    delete process.env.NEXTAUTH_URL;
+  });
+
+  it('returns an absolute recipient URL when the application origin is configured', () => {
+    process.env.NEXTAUTH_URL = 'https://certificates.example';
+    expect(createSignedGeneratedFileUrl('u_user/session/certificate.pdf'))
+      .toMatch(/^https:\/\/certificates\.example\/api\/files\/download\?/);
+  });
+
+  it('creates and verifies a bounded signed URL', () => {
+    const url = new URL(
+      createSignedGeneratedFileUrl('individual_1/Alice Smith.pdf', 60, 1_000_000),
+      'https://certificates.example',
+    );
+
+    expect(url.pathname).toBe('/api/files/download');
+    expect(verifySignedGeneratedFileUrl(
+      url.searchParams.get('path')!,
+      url.searchParams.get('expires')!,
+      url.searchParams.get('signature')!,
+      1_030_000,
+    )).toBe('individual_1/Alice Smith.pdf');
+  });
+
+  it('rejects tampering, expiry, traversal, and non-PDF paths', () => {
+    const url = new URL(
+      createSignedGeneratedFileUrl('session/certificate.pdf', 60, 1_000_000),
+      'https://certificates.example',
+    );
+    const expires = url.searchParams.get('expires')!;
+    const signature = url.searchParams.get('signature')!;
+
+    expect(() => verifySignedGeneratedFileUrl('session/other.pdf', expires, signature, 1_000_000))
+      .toThrow(SignedFileUrlError);
+    expect(() => verifySignedGeneratedFileUrl('session/certificate.pdf', expires, signature, 1_061_000))
+      .toThrow(SignedFileUrlError);
+    expect(() => normalizeGeneratedPdfPath('../secret.pdf')).toThrow(SignedFileUrlError);
+    expect(() => normalizeGeneratedPdfPath('session/secret.txt')).toThrow(SignedFileUrlError);
+  });
+
+  it('requires a signing secret', () => {
+    delete process.env.FILE_URL_SIGNING_SECRET;
+    delete process.env.NEXTAUTH_SECRET;
+    const previousNodeEnv = process.env.NODE_ENV;
+    Object.defineProperty(process.env, 'NODE_ENV', { configurable: true, value: 'production' });
+    try {
+      expect(() => createSignedGeneratedFileUrl('session/certificate.pdf'))
+        .toThrow(SignedFileUrlError);
+    } finally {
+      Object.defineProperty(process.env, 'NODE_ENV', { configurable: true, value: previousNodeEnv });
+    }
+  });
+});

--- a/__tests__/lib/storage-urls.test.ts
+++ b/__tests__/lib/storage-urls.test.ts
@@ -1,0 +1,43 @@
+import {
+  normalizeLegacyPrivateAssetReference,
+  normalizeLegacyPrivateAssetUrl,
+} from '@/lib/storage-urls';
+
+describe('legacy private asset URLs', () => {
+  it('routes saved temporary-image URLs through the authenticated API', () => {
+    expect(normalizeLegacyPrivateAssetUrl('/temp_images/u_user/template.jpg'))
+      .toBe('/api/files/temp_images/u_user/template.jpg');
+  });
+
+  it('scopes the legacy PDF filename alongside its saved image URL', () => {
+    expect(normalizeLegacyPrivateAssetReference(
+      '/temp_images/u_user/template.jpg',
+      'template.pdf',
+    )).toEqual({
+      url: '/api/files/temp_images/u_user/template.jpg',
+      filename: 'u_user/template.pdf',
+    });
+  });
+
+  it('normalizes legacy absolute cloud URLs and their PDF filename', () => {
+    expect(normalizeLegacyPrivateAssetReference(
+      'https://certs.example.com/bucket/temp_images/u_user/template.jpg?signature=old',
+      'template.pdf',
+    )).toEqual({
+      url: '/api/files/temp_images/u_user/template.jpg',
+      filename: 'u_user/template.pdf',
+    });
+  });
+
+  it('does not normalize malformed traversal-like cloud paths', () => {
+    expect(normalizeLegacyPrivateAssetUrl(
+      'https://certs.example.com/temp_images/u_user/../secret.pdf',
+    )).toBe('https://certs.example.com/temp_images/u_user/../secret.pdf');
+  });
+
+  it('does not rewrite unrelated or bundled public assets', () => {
+    expect(normalizeLegacyPrivateAssetUrl('/template_images/dev-mode-template.jpg'))
+      .toBe('/template_images/dev-mode-template.jpg');
+    expect(normalizeLegacyPrivateAssetUrl('blob:local')).toBe('blob:local');
+  });
+});

--- a/__tests__/lib/trusted-pdf-source.test.ts
+++ b/__tests__/lib/trusted-pdf-source.test.ts
@@ -8,6 +8,7 @@ import {
   validateTrustedRemotePdfUrl,
 } from '@/lib/security/trusted-pdf-source';
 import { getGeneratedDir } from '@/lib/paths';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
 
 const originalEnv = process.env;
 const originalFetch = global.fetch;
@@ -51,6 +52,7 @@ describe('trusted PDF source loading', () => {
       R2_PUBLIC_URL: 'https://certs.example.com',
       S3_BUCKET_NAME: 'certificate-bucket',
       S3_REGION: 'ap-southeast-1',
+      NEXTAUTH_SECRET: 'test-signing-secret',
     };
     global.fetch = jest.fn();
   });
@@ -136,12 +138,23 @@ describe('trusted PDF source loading', () => {
   });
 
   it('confines local sources to generated PDF paths', () => {
-    expect(resolveManagedLocalPdfPath('/generated/session/cert.pdf'))
-      .toContain('public/generated/session/cert.pdf');
+    const signedUrl = createSignedGeneratedFileUrl('session/cert.pdf');
+    expect(resolveManagedLocalPdfPath(signedUrl)).toContain('storage/generated/session/cert.pdf');
+    expect(() => resolveManagedLocalPdfPath('/generated/session/cert.pdf'))
+      .toThrow(PdfSourceError);
     expect(() => resolveManagedLocalPdfPath('/generated/../../package.pdf'))
       .toThrow(PdfSourceError);
     expect(() => resolveManagedLocalPdfPath('/api/files/temp_images/u_1/cert.pdf'))
       .toThrow(PdfSourceError);
+  });
+
+  it('accepts only valid signed local download sources', () => {
+    const signedUrl = createSignedGeneratedFileUrl('session/cert.pdf');
+    expect(resolveManagedLocalPdfPath(signedUrl))
+      .toContain('storage/generated/session/cert.pdf');
+
+    const tamperedUrl = signedUrl.replace('session%2Fcert.pdf', 'session%2Fother.pdf');
+    expect(() => resolveManagedLocalPdfPath(tamperedUrl)).toThrow(PdfSourceError);
   });
 
   it('rejects local symlinks that resolve outside generated storage', async () => {
@@ -154,7 +167,7 @@ describe('trusted PDF source loading', () => {
         : '/private/outside.pdf';
     }) as typeof fs.realpathSync);
 
-    await expect(loadTrustedPdf('/generated/link.pdf'))
+    await expect(loadTrustedPdf(createSignedGeneratedFileUrl('link.pdf')))
       .rejects.toMatchObject({ code: 'INVALID_SOURCE', statusCode: 403 });
     expect(readFile).not.toHaveBeenCalled();
   });
@@ -173,7 +186,7 @@ describe('trusted PDF source loading', () => {
     } as fs.Stats);
     jest.spyOn(fs, 'readFileSync').mockReturnValue(pdf);
 
-    await expect(loadTrustedPdf('/generated/session/certificate.pdf'))
+    await expect(loadTrustedPdf(createSignedGeneratedFileUrl('session/certificate.pdf')))
       .resolves.toEqual({ buffer: pdf, source: 'local' });
   });
 

--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -39,7 +39,7 @@ describe('authentication middleware', () => {
     '/logo.png',
     '/pdf-worker.js',
     '/fonts/Rubik-Regular.ttf',
-    '/generated/progressive_session/certificate.pdf',
+    '/api/files/download?path=session%2Fcertificate.pdf&expires=1&signature=x',
   ])(
     'allows public path %s without reading a token',
     async pathname => {
@@ -83,8 +83,8 @@ describe('authentication middleware', () => {
     expect(response.status).toBe(401);
   });
 
-  it.each(['/private/certificate.pdf', '/generated.pdf'])(
-    'does not exempt PDF path %s outside the legacy generated download directory',
+  it.each(['/private/certificate.pdf', '/generated/session/certificate.pdf', '/generated.pdf'])(
+    'does not exempt unsigned PDF path %s',
     async pathname => {
       mockedGetToken.mockResolvedValue(null);
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,10 +18,10 @@ services:
       - .:/app
       - /app/node_modules  # Prevent overwriting node_modules
       - /app/.next         # Prevent overwriting .next build cache
-      # Persist uploaded templates and generated PDFs
-      - ./data/temp_images:/app/public/temp_images
-      - ./data/generated:/app/public/generated
-      - ./data/template_images:/app/public/template_images
+      # Persist user files outside Next.js' publicly served directory
+      - ./data/temp_images:/app/storage/temp_images
+      - ./data/generated:/app/storage/generated
+      - ./data/template_images:/app/storage/template_images
       # Optional: persist local SQLite database across restarts (uncomment if desired)
       # - ./data/dev/database.db:/app/prisma/database.db
     command: sh -c "npx prisma generate && npm run dev"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,10 @@ services:
       NEXT_TELEMETRY_DISABLED: 1
       CLIENT_MAX_BODY_SIZE: 20M # nginx-proxy max upload size
     volumes:
-      # Persist uploaded templates and generated PDFs
-      - ./data/temp_images:/app/public/temp_images
-      - ./data/generated:/app/public/generated
-      - ./data/template_images:/app/public/template_images
+      # Persist user files outside Next.js' publicly served directory
+      - ./data/temp_images:/app/storage/temp_images
+      - ./data/generated:/app/storage/generated
+      - ./data/template_images:/app/storage/template_images
       # Persist SQLite database file only (preserves schema.prisma from image)
       - ./data/database.db:/app/prisma/database.db
     networks:

--- a/hooks/useClientPdfGeneration.ts
+++ b/hooks/useClientPdfGeneration.ts
@@ -232,8 +232,9 @@ export function useClientPdfGeneration({
       if (uploadedFile.includes('dev-mode-template')) {
         return `/template_images/${uploadedFile}`;
       }
-      // For other strings, assume they're filenames that need local paths
-      return `/temp_images/${uploadedFile}`;
+      // Persisted uploads are served through authenticated API routes.
+      const encodedPath = uploadedFile.split('/').map(segment => encodeURIComponent(segment)).join('/');
+      return `/api/files/temp_images/${encodedPath}`;
     }
     
     return null;

--- a/hooks/useProjectManagement.tsx
+++ b/hooks/useProjectManagement.tsx
@@ -3,6 +3,7 @@ import type { SavedProject } from "@/lib/project-storage";
 import type { EmailConfig, TableData } from "@/types/certificate";
 import { ProjectStorage } from "@/lib/project-storage";
 import { SessionStorage } from "@/lib/session-storage";
+import { normalizeLegacyPrivateAssetReference } from "@/lib/storage-urls";
 import {
   applyAutomaticTextColor,
   normalizeAutomaticTextColorProvenance
@@ -182,8 +183,12 @@ export function useProjectManagement({
 
           // Load the certificate image
           if (project.certificateImage.url) {
-            setUploadedFileUrl(project.certificateImage.url);
-            setUploadedFile(project.certificateImage.filename);
+            const asset = normalizeLegacyPrivateAssetReference(
+              project.certificateImage.url,
+              project.certificateImage.filename,
+            );
+            setUploadedFileUrl(asset.url);
+            setUploadedFile(asset.filename);
           }
 
           showToast({
@@ -258,8 +263,12 @@ export function useProjectManagement({
 
       // Update the certificate image URL and file
       if (project.certificateImage.url) {
-        setUploadedFileUrl(project.certificateImage.url);
-        setUploadedFile(project.certificateImage.filename);
+        const asset = normalizeLegacyPrivateAssetReference(
+          project.certificateImage.url,
+          project.certificateImage.filename,
+        );
+        setUploadedFileUrl(asset.url);
+        setUploadedFile(asset.filename);
       }
 
       console.log("Project loaded successfully:", project.name);

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -18,24 +18,48 @@ export function getPublicDir(): string {
 }
 
 /**
+ * Private local storage. Persisted user files must never be placed under
+ * Next.js' public directory, where they bypass API authorization entirely.
+ */
+export function getLocalStorageDir(): string {
+  const configuredDir = process.env.LOCAL_STORAGE_DIR;
+  if (configuredDir) {
+    return path.isAbsolute(configuredDir)
+      ? configuredDir
+      : path.resolve(process.cwd(), configuredDir);
+  }
+  return path.join(process.cwd(), 'storage');
+}
+
+/**
  * Get the temp images directory path
  */
 export function getTempImagesDir(): string {
-  return path.join(getPublicDir(), 'temp_images');
+  return path.join(getLocalStorageDir(), 'temp_images');
 }
 
 /**
  * Get the template images directory path
  */
 export function getTemplateImagesDir(): string {
-  return path.join(getPublicDir(), 'template_images');
+  return path.join(getLocalStorageDir(), 'template_images');
 }
 
 /**
  * Get the generated files directory path
  */
 export function getGeneratedDir(): string {
-  return path.join(getPublicDir(), 'generated');
+  return path.join(getLocalStorageDir(), 'generated');
+}
+
+export function resolvePathWithin(baseDir: string, relativePath: string): string | null {
+  const resolvedBase = path.resolve(baseDir);
+  const candidate = path.resolve(resolvedBase, relativePath);
+  const relative = path.relative(resolvedBase, candidate);
+  if (!relative || relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    return null;
+  }
+  return candidate;
 }
 
 /**

--- a/lib/pdf/session-manager.ts
+++ b/lib/pdf/session-manager.ts
@@ -9,6 +9,7 @@ export class PdfSessionManager {
   private static instance: PdfSessionManager;
   private sessions: Map<string, PdfQueueManager> = new Map();
   private cleanupInterval: NodeJS.Timeout | null = null;
+  private removalListeners = new Set<(sessionId: string) => void>();
 
   private constructor() {
     // Start cleanup interval
@@ -66,7 +67,14 @@ export class PdfSessionManager {
    * Remove a session
    */
   removeSession(sessionId: string): void {
-    this.sessions.delete(sessionId);
+    if (this.sessions.delete(sessionId)) {
+      for (const listener of this.removalListeners) listener(sessionId);
+    }
+  }
+
+  onSessionRemoved(listener: (sessionId: string) => void): () => void {
+    this.removalListeners.add(listener);
+    return () => this.removalListeners.delete(listener);
   }
 
   /**
@@ -85,7 +93,7 @@ export class PdfSessionManager {
 
     for (const [sessionId, manager] of this.sessions.entries()) {
       if (manager.isExpired()) {
-        this.sessions.delete(sessionId);
+        this.removeSession(sessionId);
         cleaned++;
       }
     }
@@ -103,6 +111,7 @@ export class PdfSessionManager {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
     }
-    this.sessions.clear();
+    for (const sessionId of this.sessions.keys()) this.removeSession(sessionId);
+    this.removalListeners.clear();
   }
 }

--- a/lib/r2-client.ts
+++ b/lib/r2-client.ts
@@ -88,23 +88,14 @@ export async function uploadToR2(
   // Generate URL based on environment (DON'T force download - let frontend handle it)
   const url = await getPublicUrl(key, false);
   
-  return {
-    key,
-    url,
-    publicUrl: process.env.R2_PUBLIC_URL ? `${process.env.R2_PUBLIC_URL}/${key}` : url,
-  };
+  return { key, url };
 }
 
 /**
- * Get a public URL for a file (or signed URL if bucket is private)
+ * Get a time-limited signed URL. Persisted user files are never returned via
+ * an unsigned custom-domain URL, even when R2_PUBLIC_URL is configured.
  */
 export async function getPublicUrl(key: string, forceDownload: boolean = false): Promise<string> {
-  // If custom domain is configured, use it
-  if (process.env.R2_PUBLIC_URL) {
-    return `${process.env.R2_PUBLIC_URL}/${key}`;
-  }
-
-  // Otherwise, generate a signed URL (24 hour expiry)
   const command = new GetObjectCommand({
     Bucket: BUCKET_NAME,
     Key: key,

--- a/lib/s3-client.ts
+++ b/lib/s3-client.ts
@@ -100,12 +100,7 @@ export async function uploadToS3(
     Key: key,
   }), { expiresIn: 86400 }); // 24 hours
 
-  // Generate public URL if CloudFront is configured
-  const publicUrl = process.env.S3_CLOUDFRONT_URL 
-    ? `${process.env.S3_CLOUDFRONT_URL}/${key}`
-    : url;
-
-  return { key, url, publicUrl };
+  return { key, url };
 }
 
 /**
@@ -124,10 +119,6 @@ export async function getS3SignedUrl(key: string, expiresIn: number = 86400): Pr
  * Get public URL (if CloudFront is configured)
  */
 export async function getS3PublicUrl(key: string): Promise<string> {
-  if (process.env.S3_CLOUDFRONT_URL) {
-    return `${process.env.S3_CLOUDFRONT_URL}/${key}`;
-  }
-  // Fallback to signed URL
   return getS3SignedUrl(key);
 }
 
@@ -343,20 +334,7 @@ export async function cleanupExpiredS3Files(dryRun: boolean = false): Promise<{
 /**
  * Mark a file as emailed (extends retention)
  */
-export async function markAsEmailedS3(fileUrl: string): Promise<void> {
-  // Extract key from URL
-  let key = fileUrl;
-  
-  // Handle different URL formats
-  if (fileUrl.includes('.amazonaws.com/')) {
-    key = fileUrl.split('.amazonaws.com/')[1].split('?')[0];
-  } else if (fileUrl.includes(process.env.S3_CLOUDFRONT_URL || '')) {
-    key = fileUrl.replace(process.env.S3_CLOUDFRONT_URL + '/', '');
-  } else if (fileUrl.startsWith('/')) {
-    // Handle local URL format
-    key = fileUrl.substring(1);
-  }
-  
+export async function markAsEmailedS3(key: string): Promise<void> {
   // Update metadata
   await updateS3Metadata(key, {
     emailSent: 'true',

--- a/lib/security/private-file-access.ts
+++ b/lib/security/private-file-access.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import {
+  getPublicDir,
+  getTemplateImagesDir,
+  getTempImagesDir,
+  resolvePathWithin,
+} from '@/lib/paths';
+
+export class PrivateFileAccessError extends Error {
+  constructor(message: string, public readonly statusCode: number) {
+    super(message);
+    this.name = 'PrivateFileAccessError';
+  }
+}
+
+export function getAuthorizedTemplateCandidates(templateFilename: string, userId: string): string[] {
+  if (typeof templateFilename !== 'string' || !templateFilename || templateFilename.includes('\\')) {
+    throw new PrivateFileAccessError('Invalid template path', 400);
+  }
+  if (/^dev-mode-template\.pdf$/i.test(templateFilename)) {
+    return [path.join(getPublicDir(), 'template_images', templateFilename)];
+  }
+  if (
+    !templateFilename.startsWith(`u_${userId}/`) ||
+    path.posix.normalize(templateFilename) !== templateFilename
+  ) {
+    throw new PrivateFileAccessError('Template does not belong to the current user', 403);
+  }
+
+  const candidates = [
+    resolvePathWithin(getTemplateImagesDir(), templateFilename),
+    resolvePathWithin(getTempImagesDir(), templateFilename),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  if (candidates.length === 0) {
+    throw new PrivateFileAccessError('Invalid template path', 403);
+  }
+  return candidates;
+}

--- a/lib/security/signed-generated-url.ts
+++ b/lib/security/signed-generated-url.ts
@@ -1,0 +1,111 @@
+import crypto from 'crypto';
+import path from 'path';
+
+const DEFAULT_TTL_SECONDS = 90 * 24 * 60 * 60;
+const MAX_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+export class SignedFileUrlError extends Error {
+  constructor(message: string, public readonly statusCode: number) {
+    super(message);
+    this.name = 'SignedFileUrlError';
+  }
+}
+
+function signingSecret(): string {
+  const secret = process.env.FILE_URL_SIGNING_SECRET || process.env.NEXTAUTH_SECRET;
+  if (secret) return secret;
+  if (process.env.NODE_ENV !== 'production') return 'bamboobot-local-development-only';
+  throw new SignedFileUrlError('File URL signing is not configured', 500);
+}
+
+export function normalizeGeneratedPdfPath(value: string): string {
+  if (!value || value.includes('\0') || value.includes('\\')) {
+    throw new SignedFileUrlError('Invalid generated file path', 400);
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    throw new SignedFileUrlError('Invalid generated file path', 400);
+  }
+
+  const normalized = path.posix.normalize(decoded).replace(/^\/+/, '');
+  if (
+    !normalized ||
+    normalized === '.' ||
+    normalized.startsWith('../') ||
+    path.posix.isAbsolute(normalized) ||
+    path.posix.extname(normalized).toLowerCase() !== '.pdf'
+  ) {
+    throw new SignedFileUrlError('Invalid generated PDF path', 400);
+  }
+  return normalized;
+}
+
+function signatureFor(relativePath: string, expires: number): string {
+  return crypto
+    .createHmac('sha256', signingSecret())
+    .update(`${relativePath}\n${expires}`)
+    .digest('base64url');
+}
+
+export function createSignedGeneratedFileUrl(
+  relativePath: string,
+  ttlSeconds: number = DEFAULT_TTL_SECONDS,
+  nowMs: number = Date.now(),
+): string {
+  const normalizedPath = normalizeGeneratedPdfPath(relativePath);
+  const safeTtl = Number.isFinite(ttlSeconds)
+    ? Math.min(Math.max(Math.floor(ttlSeconds), 1), MAX_TTL_SECONDS)
+    : DEFAULT_TTL_SECONDS;
+  const expires = Math.floor(nowMs / 1000) + safeTtl;
+  const signature = signatureFor(normalizedPath, expires);
+  const params = new URLSearchParams({
+    path: normalizedPath,
+    expires: String(expires),
+    signature,
+  });
+  const relativeUrl = `/api/files/download?${params.toString()}`;
+  const appOrigin = process.env.NEXTAUTH_URL;
+  if (appOrigin) {
+    try {
+      const absoluteUrl = new URL(relativeUrl, appOrigin);
+      if (absoluteUrl.protocol === 'https:' || (absoluteUrl.protocol === 'http:' && process.env.NODE_ENV !== 'production')) {
+        return absoluteUrl.toString();
+      }
+    } catch {
+      // Invalid application origin falls back to a same-origin URL.
+    }
+  }
+  return relativeUrl;
+}
+
+export function verifySignedGeneratedFileUrl(
+  relativePath: string,
+  expiresValue: string,
+  providedSignature: string,
+  nowMs: number = Date.now(),
+): string {
+  const normalizedPath = normalizeGeneratedPdfPath(relativePath);
+  if (!/^\d+$/.test(expiresValue)) {
+    throw new SignedFileUrlError('Invalid file URL expiry', 400);
+  }
+
+  const expires = Number(expiresValue);
+  const now = Math.floor(nowMs / 1000);
+  if (!Number.isSafeInteger(expires) || expires < now) {
+    throw new SignedFileUrlError('File URL has expired', 410);
+  }
+  if (expires - now > MAX_TTL_SECONDS) {
+    throw new SignedFileUrlError('File URL expiry is invalid', 403);
+  }
+
+  const expectedSignature = signatureFor(normalizedPath, expires);
+  const expected = Buffer.from(expectedSignature);
+  const provided = Buffer.from(providedSignature || '');
+  if (expected.length !== provided.length || !crypto.timingSafeEqual(expected, provided)) {
+    throw new SignedFileUrlError('Invalid file URL signature', 403);
+  }
+  return normalizedPath;
+}

--- a/lib/security/trusted-pdf-source.ts
+++ b/lib/security/trusted-pdf-source.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { getGeneratedDir } from '@/lib/paths';
+import { verifySignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+import storageConfig from '@/lib/storage-config';
+import { getPublicUrl as getR2SignedUrl } from '@/lib/r2-client';
+import { getS3SignedUrl } from '@/lib/s3-client';
 
 const DEFAULT_MAX_PDF_BYTES = 25 * 1024 * 1024;
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
@@ -137,20 +141,21 @@ export function resolveManagedLocalPdfPath(value: string): string {
     throw new PdfSourceError('INVALID_SOURCE', 'Invalid local PDF source', 400);
   }
 
-  let encodedRelativePath: string;
-  if (parsed.pathname.startsWith('/api/files/generated/')) {
-    encodedRelativePath = parsed.pathname.slice('/api/files/generated/'.length);
-  } else if (parsed.pathname.startsWith('/generated/')) {
-    encodedRelativePath = parsed.pathname.slice('/generated/'.length);
-  } else {
-    throw new PdfSourceError('INVALID_SOURCE', 'Local PDF source is outside generated storage', 400);
-  }
-
   let relativePath: string;
-  try {
-    relativePath = decodeURIComponent(encodedRelativePath);
-  } catch {
-    throw new PdfSourceError('INVALID_SOURCE', 'Invalid encoded PDF path', 400);
+  if (parsed.pathname === '/api/files/download') {
+    const signedPath = parsed.searchParams.get('path');
+    const expires = parsed.searchParams.get('expires');
+    const signature = parsed.searchParams.get('signature');
+    if (!signedPath || !expires || !signature) {
+      throw new PdfSourceError('INVALID_SOURCE', 'Incomplete signed PDF source', 400);
+    }
+    try {
+      relativePath = verifySignedGeneratedFileUrl(signedPath, expires, signature);
+    } catch {
+      throw new PdfSourceError('INVALID_SOURCE', 'Invalid signed PDF source', 403);
+    }
+  } else {
+    throw new PdfSourceError('INVALID_SOURCE', 'A signed generated PDF source is required', 403);
   }
 
   if (!relativePath || relativePath.includes('\0') || path.extname(relativePath).toLowerCase() !== '.pdf') {
@@ -306,6 +311,39 @@ export async function loadTrustedPdf(
   // Callers may request a smaller budget (for example, the remaining ZIP
   // budget), but may never raise the configured per-source ceiling.
   const effectiveMaxBytes = Math.min(maxBytes, getMaxPdfSourceBytes());
+
+  let parsedSource: URL | null = null;
+  try {
+    parsedSource = new URL(value, 'http://local.invalid');
+  } catch {
+    // The existing local/remote validation below will produce the public error.
+  }
+
+  if (parsedSource?.pathname === '/api/files/download') {
+    const signedPath = parsedSource.searchParams.get('path');
+    const expires = parsedSource.searchParams.get('expires');
+    const signature = parsedSource.searchParams.get('signature');
+    if (!signedPath || !expires || !signature) {
+      throw new PdfSourceError('INVALID_SOURCE', 'Incomplete signed PDF source', 400);
+    }
+
+    let verifiedPath: string;
+    try {
+      verifiedPath = verifySignedGeneratedFileUrl(signedPath, expires, signature);
+    } catch {
+      throw new PdfSourceError('INVALID_SOURCE', 'Invalid signed PDF source', 403);
+    }
+
+    if (storageConfig.isR2Enabled) {
+      const providerUrl = await getR2SignedUrl(`generated/${verifiedPath}`);
+      return { buffer: await fetchTrustedRemotePdf(providerUrl, effectiveMaxBytes, options.timeoutMs), source: 'remote' };
+    }
+    if (storageConfig.isS3Enabled) {
+      const providerUrl = await getS3SignedUrl(`generated/${verifiedPath}`);
+      return { buffer: await fetchTrustedRemotePdf(providerUrl, effectiveMaxBytes, options.timeoutMs), source: 'remote' };
+    }
+    return { buffer: readManagedLocalPdf(parsedSource.pathname + parsedSource.search, effectiveMaxBytes), source: 'local' };
+  }
 
   if (/^https?:\/\//i.test(value)) {
     return {

--- a/lib/storage-config.ts
+++ b/lib/storage-config.ts
@@ -3,6 +3,7 @@
 
 import { uploadToR2, getPublicUrl, isR2Configured } from './r2-client';
 import { uploadToS3, getS3PublicUrl, isS3Configured } from './s3-client';
+import { createSignedGeneratedFileUrl } from './security/signed-generated-url';
 
 export const storageConfig = {
   // Check if R2 is configured
@@ -26,30 +27,19 @@ export const storageConfig = {
   // URL generation based on environment
   getFileUrl: (filename: string, subdirectory?: string, type: 'generated' | 'temp_images' = 'generated'): string => {
     const path = subdirectory ? `${subdirectory}/${filename}` : filename;
-    
-    if (process.env.NODE_ENV === 'development') {
-      // In development, serve directly from public folder
-      return `/${type}/${path}`;
+    if (type === 'generated') {
+      return createSignedGeneratedFileUrl(path);
     }
     
     // In production, check storage provider
     switch (process.env.STORAGE_PROVIDER) {
       case 'amazon-s3':
-        // Return S3 URL or CloudFront URL
-        if (process.env.S3_CLOUDFRONT_URL) {
-          return `${process.env.S3_CLOUDFRONT_URL}/${type}/${path}`;
-        }
-        // Fallback to API route for signed URLs
+        // API routes authenticate access and issue provider-signed redirects.
         return `/api/files/${type}/${path}`;
       case 'cloudflare-r2':
-        // Return R2 public URL if configured
-        if (process.env.R2_PUBLIC_URL) {
-          return `${process.env.R2_PUBLIC_URL}/${type}/${path}`;
-        }
-        // Fallback to API route for signed URLs
+        // Never expose persisted user objects through an unsigned custom domain.
         return `/api/files/${type}/${path}`;
       default:
-        // Fallback to API route (current behavior)
         return `/api/files/${type}/${path}`;
     }
   },

--- a/lib/storage-manager.ts
+++ b/lib/storage-manager.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import storageConfig from './storage-config';
 import { listFiles as listR2Files, deleteFromR2 } from './r2-client';
 import { listAllS3Objects, deleteFromS3 } from './s3-client';
-import { getGeneratedDir, getTempImagesDir } from './paths';
+import { getGeneratedDir, getLocalStorageDir, getTempImagesDir } from './paths';
 
 export type StorageProvider = 'local' | 'cloudflare-r2' | 'amazon-s3';
 
@@ -41,7 +41,7 @@ function walkLocal(dir: string, basePrefix: string): StorageItem[] {
         stack.push(full);
         continue;
       }
-      const rel = path.relative(path.join(process.cwd(), 'public'), full).replaceAll('\\', '/');
+      const rel = path.relative(getLocalStorageDir(), full).replaceAll('\\', '/');
       items.push({
         key: `${rel}`,
         size: stat.size,
@@ -130,7 +130,7 @@ export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boo
   // Local deletions
   for (const a of safeActions) {
     try {
-      const full = path.join(process.cwd(), 'public', a.key);
+      const full = path.join(getLocalStorageDir(), a.key);
       if (a.isPrefix) {
         // Delete everything under the directory
         if (fs.existsSync(full)) {
@@ -143,7 +143,7 @@ export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boo
             // Fallback: walk both roots and remove filtered
             const all = await listAllObjects(a.key);
             for (const f of all) {
-              const abs = path.join(process.cwd(), 'public', f.key);
+              const abs = path.join(getLocalStorageDir(), f.key);
               if (fs.existsSync(abs)) fs.rmSync(abs, { force: true });
               deleted.push(f.key);
             }
@@ -173,4 +173,3 @@ export function formatBytes(bytes: number): string {
   const value = bytes / Math.pow(k, i);
   return `${value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2)} ${sizes[i]}`;
 }
-

--- a/lib/storage-urls.ts
+++ b/lib/storage-urls.ts
@@ -1,0 +1,43 @@
+function getLegacyTempImagePath(value: string): string | null {
+  let pathname = value;
+  if (/^https?:\/\//i.test(value)) {
+    try {
+      pathname = new URL(value).pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  const match = pathname.match(/(?:^|\/)temp_images\/(u_[^/]+\/.+)$/);
+  if (!match) return null;
+  const privatePath = match[1];
+  const segments = privatePath.split('/');
+  if (
+    privatePath.includes('\\') ||
+    segments.some(segment => !segment || segment === '.' || segment === '..')
+  ) {
+    return null;
+  }
+  return privatePath;
+}
+
+export function normalizeLegacyPrivateAssetUrl(value: string): string {
+  const privatePath = getLegacyTempImagePath(value);
+  if (privatePath) return `/api/files/temp_images/${privatePath}`;
+  return value;
+}
+
+export function normalizeLegacyPrivateAssetReference(
+  url: string,
+  filename: string,
+): { url: string; filename: string } {
+  const privatePath = getLegacyTempImagePath(url);
+  const userNamespace = privatePath?.split('/')[0];
+  const scopedFilename = userNamespace && !filename.includes('/')
+    ? `${userNamespace}/${filename}`
+    : filename;
+  return {
+    url: normalizeLegacyPrivateAssetUrl(url),
+    filename: scopedFilename,
+  };
+}

--- a/lib/storage/mark-generated.ts
+++ b/lib/storage/mark-generated.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+import { isR2Configured, markAsEmailed } from '@/lib/r2-client';
+import { isS3Configured, markAsEmailedS3 } from '@/lib/s3-client';
+import { getGeneratedDir, resolvePathWithin } from '@/lib/paths';
+import {
+  SignedFileUrlError,
+  verifySignedGeneratedFileUrl,
+} from '@/lib/security/signed-generated-url';
+
+export async function markGeneratedFileAsEmailed(fileUrl: string, userId: string): Promise<void> {
+  const provider = process.env.STORAGE_PROVIDER || 'local';
+
+  let parsed: URL;
+  try {
+    parsed = new URL(fileUrl, 'http://local.invalid');
+  } catch {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+  if (parsed.pathname !== '/api/files/download') {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+
+  const signedPath = parsed.searchParams.get('path');
+  const expires = parsed.searchParams.get('expires');
+  const signature = parsed.searchParams.get('signature');
+  if (!signedPath || !expires || !signature) {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+
+  const verifiedPath = verifySignedGeneratedFileUrl(signedPath, expires, signature);
+  if (!verifiedPath.startsWith(`u_${userId}/`)) {
+    throw new SignedFileUrlError('Generated file does not belong to the current user', 403);
+  }
+  const key = `generated/${verifiedPath}`;
+
+  if (provider === 'local') {
+    const generatedDir = getGeneratedDir();
+    const filePath = resolvePathWithin(generatedDir, verifiedPath);
+    if (!filePath || !fs.existsSync(filePath)) {
+      throw new SignedFileUrlError('Generated file not found', 404);
+    }
+    const realBase = fs.realpathSync(generatedDir);
+    const realFile = fs.realpathSync(filePath);
+    const relativeRealPath = path.relative(realBase, realFile);
+    if (
+      !relativeRealPath ||
+      relativeRealPath === '..' ||
+      relativeRealPath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeRealPath) ||
+      !fs.statSync(realFile).isFile()
+    ) {
+      throw new SignedFileUrlError('Generated file escapes private storage', 403);
+    }
+
+    const markerPath = `${realFile}.retention-90d`;
+    try {
+      fs.writeFileSync(markerPath, new Date().toISOString(), { flag: 'wx', mode: 0o600 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || !fs.lstatSync(markerPath).isFile()) {
+        throw error;
+      }
+    }
+    return;
+  }
+
+  if (provider === 'cloudflare-r2' && isR2Configured()) {
+    await markAsEmailed(key);
+    return;
+  }
+  if (provider === 'amazon-s3' && isS3Configured()) {
+    await markAsEmailedS3(key);
+    return;
+  }
+  throw new SignedFileUrlError('Storage provider is not configured', 500);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,10 +4,6 @@ import { getToken } from 'next-auth/jwt';
 import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 
 const STATIC_ASSET_PATTERN = /\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif|txt|xml|json|map|js|css|woff|woff2|ttf|otf|eot)$/i;
-// Existing email links rely on this anonymous path. Keep the exception narrow;
-// private/signed certificate delivery will replace it in the storage hardening.
-const LEGACY_PUBLIC_GENERATED_PDF_PATTERN = /^\/generated\/.+\.pdf$/i;
-
 function isPathOrDescendant(pathname: string, path: string): boolean {
   return pathname === path || pathname.startsWith(`${path}/`);
 }
@@ -23,8 +19,8 @@ export async function middleware(req: NextRequest) {
   if (
     pathname === '/' ||
     isPathOrDescendant(pathname, '/api/auth') ||
+    pathname === '/api/files/download' ||
     isPathOrDescendant(pathname, '/_next') ||
-    LEGACY_PUBLIC_GENERATED_PDF_PATTERN.test(pathname) ||
     (!isPathOrDescendant(pathname, '/api') && STATIC_ASSET_PATTERN.test(pathname))
   ) {
     return NextResponse.next();

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "predev": "node scripts/migrate-private-storage.js",
     "dev": "npm run build:worker && next dev",
     "build": "npm run build:worker && next build",
     "build:worker": "webpack --config webpack.worker.config.js",
+    "prestart": "node scripts/migrate-private-storage.js",
     "start": "next start",
+    "migrate:storage": "node scripts/migrate-private-storage.js",
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/pages/admin/system.tsx
+++ b/pages/admin/system.tsx
@@ -10,6 +10,7 @@ import AdminLayout from '@/components/admin/AdminLayout';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { getGeneratedDir, getTempImagesDir } from '@/lib/paths';
 
 interface SystemInfo {
   database: {
@@ -321,8 +322,8 @@ export const getServerSideProps: GetServerSideProps<SystemPageProps> = async (co
   ]);
   
   // Check local storage
-  const tempImagesDir = path.join(process.cwd(), 'public', 'temp_images');
-  const generatedDir = path.join(process.cwd(), 'public', 'generated');
+  const tempImagesDir = getTempImagesDir();
+  const generatedDir = getGeneratedDir();
   
   const getDirectorySize = (dir: string) => {
     let size = 0;

--- a/pages/api/admin/files/[...path].ts
+++ b/pages/api/admin/files/[...path].ts
@@ -4,12 +4,13 @@ import path from 'path';
 import { lookup } from 'mime-types';
 import type { AuthenticatedRequest } from '@/types/api';
 import { withAdminAccess } from '@/lib/server/middleware/featureGate';
+import { getLocalStorageDir, resolvePathWithin } from '@/lib/paths';
 
 function isSafe(rel: string): boolean {
   return rel.startsWith('generated/') || rel.startsWith('temp_images/');
 }
 
-async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
+export async function adminFilesHandler(req: AuthenticatedRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
@@ -20,14 +21,13 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     return;
   }
   const rel = segments.join('/');
-  if (!isSafe(rel)) {
+  if (path.posix.normalize(rel) !== rel || rel.includes('\\') || !isSafe(rel)) {
     res.status(403).json({ error: 'Access denied' });
     return;
   }
-  const full = path.join(process.cwd(), 'public', rel);
-  const normalized = path.normalize(full);
-  const base = path.join(process.cwd(), 'public');
-  if (!normalized.startsWith(base)) {
+  const base = getLocalStorageDir();
+  const full = resolvePathWithin(base, rel);
+  if (!full) {
     res.status(403).json({ error: 'Access denied' });
     return;
   }
@@ -35,17 +35,43 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
     res.status(404).json({ error: 'File not found' });
     return;
   }
-  const stat = fs.statSync(full);
-  if (stat.isDirectory()) {
-    res.status(400).json({ error: 'Path is a directory' });
-    return;
+  try {
+    const realBase = fs.realpathSync(base);
+    const realFile = fs.realpathSync(full);
+    const realRelative = path.relative(realBase, realFile);
+    if (
+      !realRelative ||
+      realRelative === '..' ||
+      realRelative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(realRelative)
+    ) {
+      res.status(403).json({ error: 'Access denied' });
+      return;
+    }
+    const stat = fs.statSync(realFile);
+    if (!stat.isFile()) {
+      res.status(400).json({ error: 'Path is not a file' });
+      return;
+    }
+    const mimeType = lookup(path.basename(realFile)) || 'application/octet-stream';
+    res.setHeader('Content-Type', mimeType);
+    res.setHeader('Content-Length', String(stat.size));
+    res.setHeader('Cache-Control', 'private, no-store');
+    const stream = fs.createReadStream(realFile);
+    stream.on('error', error => {
+      console.error('Error streaming admin file:', error);
+      if (!res.headersSent) res.status(500).end();
+      else res.destroy(error);
+    });
+    stream.pipe(res);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
+    console.error('Error serving admin file:', error);
+    res.status(500).json({ error: 'Error serving file' });
   }
-  const buf = fs.readFileSync(full);
-  const mimeType = lookup(path.basename(full)) || 'application/octet-stream';
-  res.setHeader('Content-Type', mimeType);
-  res.setHeader('Cache-Control', 'public, max-age=31536000');
-  res.send(buf);
 }
 
-export default withAdminAccess(handler);
-
+export default withAdminAccess(adminFilesHandler);

--- a/pages/api/files/download.ts
+++ b/pages/api/files/download.ts
@@ -1,0 +1,91 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+import { getGeneratedDir, resolvePathWithin } from '@/lib/paths';
+import { enforceRateLimit } from '@/lib/rate-limit';
+import storageConfig from '@/lib/storage-config';
+import { getPublicUrl as getR2SignedUrl } from '@/lib/r2-client';
+import { getS3SignedUrl } from '@/lib/s3-client';
+import {
+  SignedFileUrlError,
+  verifySignedGeneratedFileUrl,
+} from '@/lib/security/signed-generated-url';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const rl = enforceRateLimit(req, res, { route: 'files:download', category: 'download' });
+  if (!rl.allowed) {
+    res.status(429).json({ error: 'Too many download requests' });
+    return;
+  }
+
+  const relativePath = Array.isArray(req.query.path) ? '' : req.query.path;
+  const expires = Array.isArray(req.query.expires) ? '' : req.query.expires;
+  const signature = Array.isArray(req.query.signature) ? '' : req.query.signature;
+
+  if (!relativePath || !expires || !signature) {
+    res.status(400).json({ error: 'Invalid download link' });
+    return;
+  }
+
+  try {
+    const verifiedPath = verifySignedGeneratedFileUrl(relativePath, expires, signature);
+    const objectKey = `generated/${verifiedPath}`;
+    if (storageConfig.isR2Enabled) {
+      res.redirect(302, await getR2SignedUrl(objectKey));
+      return;
+    }
+    if (storageConfig.isS3Enabled) {
+      res.redirect(302, await getS3SignedUrl(objectKey));
+      return;
+    }
+
+    const filePath = resolvePathWithin(getGeneratedDir(), verifiedPath);
+    if (!filePath) {
+      throw new SignedFileUrlError('Invalid generated file path', 403);
+    }
+    const realBaseDir = fs.realpathSync(getGeneratedDir());
+    const realFilePath = fs.realpathSync(filePath);
+    const relativeRealPath = path.relative(realBaseDir, realFilePath);
+    if (
+      !relativeRealPath ||
+      relativeRealPath === '..' ||
+      relativeRealPath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeRealPath)
+    ) {
+      throw new SignedFileUrlError('Generated file escapes private storage', 403);
+    }
+
+    const stat = fs.statSync(realFilePath);
+    if (!stat.isFile()) {
+      throw new SignedFileUrlError('Generated file is not a regular file', 400);
+    }
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Length', String(stat.size));
+    res.setHeader('Content-Disposition', `inline; filename="${path.basename(verifiedPath).replace(/["\\\r\n]/g, '_')}"`);
+    res.setHeader('Cache-Control', 'private, no-store');
+    const stream = fs.createReadStream(realFilePath);
+    stream.on('error', streamError => {
+      console.error('Error streaming signed generated file:', streamError);
+      if (!res.headersSent) res.status(500).end();
+      else res.destroy(streamError);
+    });
+    stream.pipe(res);
+  } catch (error) {
+    if (error instanceof SignedFileUrlError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      res.status(404).json({ error: 'File not found' });
+      return;
+    }
+    console.error('Error serving signed generated file:', error);
+    res.status(500).json({ error: 'Error serving file' });
+  }
+}

--- a/pages/api/files/generated/[...path].ts
+++ b/pages/api/files/generated/[...path].ts
@@ -6,11 +6,13 @@ import storageConfig from '@/lib/storage-config';
 import { requireAuth } from '@/lib/auth/requireAuth';
 import { getPublicUrl as getR2SignedUrl } from '@/lib/r2-client';
 import { getS3SignedUrl } from '@/lib/s3-client';
+import { getGeneratedDir, resolvePathWithin } from '@/lib/paths';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   // Require auth for local serving and signed URL issuance
   const session = await requireAuth(req, res);
   if (!session) return;
+  const userId = (session.user as { id: string }).id;
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
@@ -23,8 +25,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
+  if (filePath[0] !== `u_${userId}`) {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+
   // Join the path segments
   const relativePath = filePath.join('/');
+  if (path.posix.normalize(relativePath) !== relativePath || relativePath.includes('\\')) {
+    res.status(403).json({ error: 'Access denied' });
+    return;
+  }
   
   try {
     // Check if we're using cloud storage
@@ -45,12 +56,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     
     // For local storage, serve from filesystem
-    const fullPath = path.join(process.cwd(), 'public', 'generated', relativePath);
-    
-    // Security check - ensure the file is within the generated directory
-    const normalizedPath = path.normalize(fullPath);
-    const generatedDir = path.join(process.cwd(), 'public', 'generated');
-    if (!normalizedPath.startsWith(generatedDir)) {
+    const generatedDir = getGeneratedDir();
+    const fullPath = resolvePathWithin(generatedDir, relativePath);
+    if (!fullPath) {
       res.status(403).json({ error: 'Access denied' });
       return;
     }
@@ -65,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const mimeType = lookup(filename) || 'application/octet-stream';
     
     res.setHeader('Content-Type', mimeType);
-    res.setHeader('Cache-Control', 'public, max-age=31536000');
+    res.setHeader('Cache-Control', 'private, no-store');
     res.send(fileBuffer);
   } catch (error) {
     console.error('Error serving file:', error);

--- a/pages/api/files/generated/[filename].ts
+++ b/pages/api/files/generated/[filename].ts
@@ -1,46 +1,15 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
-import path from 'path';
-import { lookup } from 'mime-types';
+import { requireAuth } from '@/lib/auth/requireAuth';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse): void {
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const session = await requireAuth(req, res);
+  if (!session) return;
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
 
-  const { filename } = req.query;
-  
-  if (!filename || typeof filename !== 'string') {
-    res.status(400).json({ error: 'Invalid filename' });
-    return;
-  }
-
-  const filePath = path.join(process.cwd(), 'public', 'generated', filename);
-  
-  // Security check - ensure the file is within the generated directory
-  const normalizedPath = path.normalize(filePath);
-  const generatedDir = path.join(process.cwd(), 'public', 'generated');
-  if (!normalizedPath.startsWith(generatedDir)) {
-    res.status(403).json({ error: 'Access denied' });
-    return;
-  }
-
-  if (!fs.existsSync(filePath)) {
-    res.status(404).json({ error: 'File not found' });
-    return;
-  }
-
-  try {
-    const fileBuffer = fs.readFileSync(filePath);
-    const mimeType = lookup(filename) || 'application/octet-stream';
-    
-    res.setHeader('Content-Type', mimeType);
-    res.setHeader('Cache-Control', 'public, max-age=31536000');
-    res.send(fileBuffer);
-  } catch (error) {
-    console.error('Error serving file:', error);
-    res.status(500).json({ error: 'Error serving file' });
-    return;
-  }
+  // New generated objects are always user-scoped and use the catch-all route.
+  // Unscoped legacy filenames have no trustworthy owner binding.
+  res.status(404).json({ error: 'File not found' });
 }

--- a/pages/api/files/temp_images/[...path].ts
+++ b/pages/api/files/temp_images/[...path].ts
@@ -3,6 +3,10 @@ import fs from 'fs';
 import path from 'path';
 import { lookup } from 'mime-types';
 import { requireAuth } from '@/lib/auth/requireAuth';
+import { getTempImagesDir, resolvePathWithin } from '@/lib/paths';
+import storageConfig from '@/lib/storage-config';
+import { getPublicUrl as getR2SignedUrl } from '@/lib/r2-client';
+import { getS3SignedUrl } from '@/lib/s3-client';
 
 // Serve nested temp_images paths, e.g. temp_images/u_<userId>/<filename>
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -29,16 +33,28 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const relativePath = segments.join('/');
-  const fullPath = path.join(process.cwd(), 'public', 'temp_images', relativePath);
-
-  const normalizedPath = path.normalize(fullPath);
-  const baseDir = path.join(process.cwd(), 'public', 'temp_images');
-  if (!normalizedPath.startsWith(baseDir)) {
+  if (path.posix.normalize(relativePath) !== relativePath || relativePath.includes('\\')) {
+    res.status(403).json({ error: 'Access denied' });
+    return;
+  }
+  const baseDir = getTempImagesDir();
+  const fullPath = resolvePathWithin(baseDir, relativePath);
+  if (!fullPath) {
     res.status(403).json({ error: 'Access denied' });
     return;
   }
 
+  // Uploads are always retained locally. Prefer that same-origin copy so browser
+  // PDF generation does not depend on cross-origin bucket CORS configuration.
   if (!fs.existsSync(fullPath)) {
+    if (storageConfig.isR2Enabled) {
+      res.redirect(302, await getR2SignedUrl(`temp_images/${relativePath}`));
+      return;
+    }
+    if (storageConfig.isS3Enabled) {
+      res.redirect(302, await getS3SignedUrl(`temp_images/${relativePath}`));
+      return;
+    }
     res.status(404).json({ error: 'File not found' });
     return;
   }
@@ -48,11 +64,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const filename = segments[segments.length - 1];
     const mimeType = lookup(filename) || 'application/octet-stream';
     res.setHeader('Content-Type', mimeType);
-    res.setHeader('Cache-Control', 'public, max-age=31536000');
+    res.setHeader('Cache-Control', 'private, no-store');
     res.send(buf);
   } catch (e) {
     console.error('Error serving nested temp image:', e);
     res.status(500).json({ error: 'Error serving file' });
   }
 }
-

--- a/pages/api/files/temp_images/[filename].ts
+++ b/pages/api/files/temp_images/[filename].ts
@@ -1,46 +1,14 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import fs from 'fs';
-import path from 'path';
-import { lookup } from 'mime-types';
+import { requireAuth } from '@/lib/auth/requireAuth';
 
-export default function handler(req: NextApiRequest, res: NextApiResponse): void {
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const session = await requireAuth(req, res);
+  if (!session) return;
   if (req.method !== 'GET') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
 
-  const { filename } = req.query;
-  
-  if (!filename || typeof filename !== 'string') {
-    res.status(400).json({ error: 'Invalid filename' });
-    return;
-  }
-
-  const filePath = path.join(process.cwd(), 'public', 'temp_images', filename);
-  
-  // Security check - ensure the file is within the temp_images directory
-  const normalizedPath = path.normalize(filePath);
-  const tempImagesDir = path.join(process.cwd(), 'public', 'temp_images');
-  if (!normalizedPath.startsWith(tempImagesDir)) {
-    res.status(403).json({ error: 'Access denied' });
-    return;
-  }
-
-  if (!fs.existsSync(filePath)) {
-    res.status(404).json({ error: 'File not found' });
-    return;
-  }
-
-  try {
-    const fileBuffer = fs.readFileSync(filePath);
-    const mimeType = lookup(filename) || 'application/octet-stream';
-    
-    res.setHeader('Content-Type', mimeType);
-    res.setHeader('Cache-Control', 'public, max-age=31536000');
-    res.send(fileBuffer);
-  } catch (error) {
-    console.error('Error serving file:', error);
-    res.status(500).json({ error: 'Error serving file' });
-    return;
-  }
+  // Uploaded files are user-scoped and served only by the catch-all route.
+  res.status(404).json({ error: 'File not found' });
 }

--- a/pages/api/files/template_images/[filename].ts
+++ b/pages/api/files/template_images/[filename].ts
@@ -1,16 +1,29 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import fs from 'fs';
 import path from 'path';
+import { requireAuth } from '@/lib/auth/requireAuth';
+import { getPublicDir } from '@/lib/paths';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+  const session = await requireAuth(req, res);
+  if (!session) return;
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
   const { filename } = req.query;
 
-  if (!filename || typeof filename !== 'string') {
+  if (!filename || typeof filename !== 'string' || path.basename(filename) !== filename || filename.includes('\0')) {
     res.status(400).json({ error: 'Invalid filename' });
     return;
   }
 
-  const filePath = path.join(process.cwd(), 'public', 'template_images', filename);
+  if (!/^dev-mode-template\.(?:pdf|jpe?g)$/i.test(filename)) {
+    res.status(404).json({ error: 'File not found' });
+    return;
+  }
+  const filePath = path.join(getPublicDir(), 'template_images', filename);
 
   try {
     // Check if file exists
@@ -42,7 +55,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Set appropriate headers
     res.setHeader('Content-Type', contentType);
     res.setHeader('Content-Length', fileBuffer.length.toString());
-    res.setHeader('Cache-Control', 'public, max-age=31536000'); // Cache for 1 year since templates are permanent
+    res.setHeader('Cache-Control', 'private, no-store');
     
     // Send file
     res.send(fileBuffer);

--- a/pages/api/generate-progressive.ts
+++ b/pages/api/generate-progressive.ts
@@ -18,13 +18,19 @@ import { generateSinglePdf, type Entry, type Position } from '@/lib/pdf-generato
 import type { PdfQueueItem } from '@/lib/pdf/types';
 import path from 'path';
 import fs from 'fs/promises';
+import fsSync from 'fs';
 import storageConfig from '@/lib/storage-config';
 import { uploadToR2 } from '@/lib/r2-client';
+import { uploadToS3 } from '@/lib/s3-client';
 import { debug, error } from '@/lib/log';
 import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
+import { getGeneratedDir } from '@/lib/paths';
+import { getAuthorizedTemplateCandidates, PrivateFileAccessError } from '@/lib/security/private-file-access';
 
 const sessionManager = PdfSessionManager.getInstance();
+const sessionOwners = new Map<string, string>();
+sessionManager.onSessionRemoved(sessionId => sessionOwners.delete(sessionId));
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {
   // Require auth for all methods (middleware also enforces when enabled)
@@ -38,21 +44,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         {
           const rl = enforceRateLimit(req, res, { userId, route: 'generate-progressive:POST', category: 'generate' });
           if (!rl.allowed) { res.status(429).json({ error: 'Rate limit exceeded for batch generation.' }); return; }
-          await handlePost(req, res);
+          await handlePost(req, res, userId);
         }
         return;
       case 'GET':
         {
           const rl = enforceRateLimit(req, res, { userId, route: 'generate-progressive:GET', category: 'api' });
           if (!rl.allowed) { res.status(429).json({ error: 'Too many status checks.' }); return; }
-          await handleGet(req, res);
+          await handleGet(req, res, userId);
         }
         return;
       case 'PUT':
         {
           const rl = enforceRateLimit(req, res, { userId, route: 'generate-progressive:PUT', category: 'api' });
           if (!rl.allowed) { res.status(429).json({ error: 'Too many control requests.' }); return; }
-          await handlePut(req, res);
+          await handlePut(req, res, userId);
         }
         return;
       default:
@@ -72,7 +78,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 /**
  * Start a new progressive PDF generation session
  */
-async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+async function handlePost(req: NextApiRequest, res: NextApiResponse, userId: string): Promise<void> {
   const {
     templateFilename,
     data,
@@ -94,14 +100,24 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     return;
   }
 
+  try {
+    getAuthorizedTemplateCandidates(templateFilename, userId);
+  } catch (accessError) {
+    if (accessError instanceof PrivateFileAccessError) {
+      res.status(accessError.statusCode).json({ error: accessError.message });
+      return;
+    }
+    throw accessError;
+  }
+
   // Create session
   const sessionId = `pdf-${Date.now()}-${uuidv4().slice(0, 8)}`;
   
   try {
     // Create session directory
     const sessionDir = mode === 'individual' 
-      ? path.join(process.cwd(), 'public', 'generated', `progressive_${sessionId}`)
-      : path.join(process.cwd(), 'public', 'generated');
+      ? path.join(getGeneratedDir(), `u_${userId}`, `progressive_${sessionId}`)
+      : getGeneratedDir();
     
     if (mode === 'individual') {
       await fs.mkdir(sessionDir, { recursive: true });
@@ -116,6 +132,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
       mode,
       { batchSize }
     );
+    sessionOwners.set(sessionId, userId);
 
     // Initialize queue with data
     await queueManager.initializeQueue(data, namingColumn);
@@ -136,6 +153,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     return;
   } catch (err) {
     sessionManager.removeSession(sessionId);
+    sessionOwners.delete(sessionId);
     throw err;
   }
 }
@@ -143,7 +161,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
 /**
  * Get progress of a PDF generation session
  */
-async function handleGet(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+async function handleGet(req: NextApiRequest, res: NextApiResponse, userId: string): Promise<void> {
   const { sessionId } = req.query;
 
   if (!sessionId || typeof sessionId !== 'string') {
@@ -152,7 +170,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse): Promise<voi
   }
 
   const queueManager = sessionManager.getSession(sessionId);
-  if (!queueManager) {
+  if (!queueManager || sessionOwners.get(sessionId) !== userId) {
     res.status(404).json({ error: 'Session not found' });
     return;
   }
@@ -176,7 +194,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse): Promise<voi
 /**
  * Control a PDF generation session (pause, resume, cancel)
  */
-async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<void> {
+async function handlePut(req: NextApiRequest, res: NextApiResponse, userId: string): Promise<void> {
   const { sessionId } = req.query;
   const { action } = req.body;
 
@@ -191,7 +209,7 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
   }
 
   const queueManager = sessionManager.getSession(sessionId);
-  if (!queueManager) {
+  if (!queueManager || sessionOwners.get(sessionId) !== userId) {
     res.status(404).json({ error: 'Session not found' });
     return;
   }
@@ -206,13 +224,14 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
         // Continue processing
         const queue = queueManager.getQueue();
         const sessionDir = queue.mode === 'individual'
-          ? path.join(process.cwd(), 'public', 'generated', `progressive_${sessionId}`)
-          : path.join(process.cwd(), 'public', 'generated');
+          ? path.join(getGeneratedDir(), `u_${userId}`, `progressive_${sessionId}`)
+          : getGeneratedDir();
         processNextBatch(sessionId, sessionDir);
         break;
       case 'cancel':
         await queueManager.cancel();
         sessionManager.removeSession(sessionId);
+        sessionOwners.delete(sessionId);
         break;
     }
 
@@ -253,7 +272,11 @@ async function processNextBatch(sessionId: string, sessionDir: string) {
     const { completed, failed } = await queueManager.processNextBatch(
       async (item: PdfQueueItem) => {
         // Generate PDF for this item
-        const templatePath = path.join(process.cwd(), 'public', 'temp_images', queue.templateFile);
+        const ownerId = sessionOwners.get(sessionId);
+        if (!ownerId) throw new Error('PDF session owner not found');
+        const templatePath = getAuthorizedTemplateCandidates(queue.templateFile, ownerId)
+          .find(candidate => fsSync.existsSync(candidate));
+        if (!templatePath) throw new Error('Template not found');
         
         const filename = queue.namingColumn && item.data[queue.namingColumn]
           ? `${String(item.data[queue.namingColumn]).replace(/[^a-zA-Z0-9-_]/g, '_')}.pdf`
@@ -280,14 +303,19 @@ async function processNextBatch(sessionId: string, sessionDir: string) {
             // Read the generated file
             const pdfBuffer = await fs.readFile(outputPath);
             // Upload to R2
-            const r2Key = `generated/progressive_${sessionId}/${filename}`;
-            const uploadResult = await uploadToR2(pdfBuffer, r2Key, 'application/pdf', filename);
-            fileUrl = uploadResult.url;
+            const relativeDir = `u_${ownerId}/progressive_${sessionId}`;
+            await uploadToR2(pdfBuffer, `generated/${relativeDir}/${filename}`, 'application/pdf', filename);
+            fileUrl = storageConfig.getFileUrl(filename, relativeDir);
             // Delete local file after upload
             await fs.unlink(outputPath);
+          } else if (storageConfig.isS3Enabled) {
+            const pdfBuffer = await fs.readFile(outputPath);
+            const relativeDir = `u_${ownerId}/progressive_${sessionId}`;
+            await uploadToS3(pdfBuffer, `generated/${relativeDir}/${filename}`, 'application/pdf', filename);
+            fileUrl = storageConfig.getFileUrl(filename, relativeDir);
+            await fs.unlink(outputPath);
           } else {
-            // Return local URL
-            fileUrl = `/generated/progressive_${sessionId}/${filename}`;
+            fileUrl = storageConfig.getFileUrl(filename, `u_${ownerId}/progressive_${sessionId}`);
           }
           
           // Return URL

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -18,10 +18,13 @@ import path from 'path';
 import * as fontkit from '@pdf-lib/fontkit';
 import storageConfig from '@/lib/storage-config';
 import { uploadToR2 } from '@/lib/r2-client';
+import { uploadToS3 } from '@/lib/s3-client';
 import fs from 'fs';
 import { debug, error } from '@/lib/log';
 import { rateLimit, buildKey } from '@/lib/rate-limit';
 import { withFeatureGate } from '@/lib/server/middleware/featureGate';
+import { getGeneratedDir } from '@/lib/paths';
+import { getAuthorizedTemplateCandidates, PrivateFileAccessError } from '@/lib/security/private-file-access';
 import {
   Entry,
   Position,
@@ -86,61 +89,23 @@ async function generateHandler(req: AuthenticatedRequest, res: NextApiResponse):
       return;
     }
     
-    // Handle R2 storage - download template if using R2
-    let templatePdfBytes: Buffer;
-    
     debug('Looking for template:', templateFilename);
-    
-    // Check if this is a template file (e.g., dev-mode-template.pdf)
-    // const isTemplate = templateFilename.startsWith('dev-mode-template');
-    
-    if (storageConfig.isR2Enabled) {
-      // For R2, we need to handle the template differently
-      // Check both directories as files might be in either location
-      const templateImagePath = path.join(process.cwd(), 'public', 'template_images', templateFilename);
-      const tempImagePath = path.join(process.cwd(), 'public', 'temp_images', templateFilename);
-      
-      debug('R2 mode - checking for template in both directories');
-      
-      let localTemplatePath: string | null = null;
-      if (fs.existsSync(templateImagePath)) {
-        localTemplatePath = templateImagePath;
-        debug('Template found in template_images:', localTemplatePath);
-      } else if (fs.existsSync(tempImagePath)) {
-        localTemplatePath = tempImagePath;
-        debug('Template found in temp_images:', localTemplatePath);
-      }
-      
-      if (localTemplatePath) {
-        templatePdfBytes = await fsPromises.readFile(localTemplatePath);
-        debug('Template loaded successfully, size:', templatePdfBytes.length);
-      } else {
-        error('Template not found in either directory:', { templateImagePath, tempImagePath });
-        res.status(404).json({ error: 'Template not found' });
+    let templateCandidates: string[];
+    try {
+      templateCandidates = getAuthorizedTemplateCandidates(templateFilename, userId);
+    } catch (accessError) {
+      if (accessError instanceof PrivateFileAccessError) {
+        res.status(accessError.statusCode).json({ error: accessError.message });
         return;
       }
-    } else {
-      // Check both directories - template_images first, then temp_images
-      const templateImagePath = path.join(process.cwd(), 'public', 'template_images', templateFilename);
-      const tempImagePath = path.join(process.cwd(), 'public', 'temp_images', templateFilename);
-      
-      let templatePath: string | null = null;
-      
-      // Check both locations regardless of isTemplate flag
-      if (fs.existsSync(templateImagePath)) {
-        templatePath = templateImagePath;
-        debug('Local mode - reading template from template_images:', templatePath);
-      } else if (fs.existsSync(tempImagePath)) {
-        templatePath = tempImagePath;
-        debug('Local mode - reading from temp_images:', templatePath);
-      } else {
-        error('Template not found in either directory:', { templateImagePath, tempImagePath });
-        res.status(404).json({ error: 'Template not found in both template_images and temp_images' });
-        return;
-      }
-      
-      templatePdfBytes = await fsPromises.readFile(templatePath);
+      throw accessError;
     }
+    const templatePath = templateCandidates.find(candidate => fs.existsSync(candidate));
+    if (!templatePath) {
+      res.status(404).json({ error: 'Template not found' });
+      return;
+    }
+    const templatePdfBytes = await fsPromises.readFile(templatePath);
     
     const pdfDoc = await PDFDocument.load(templatePdfBytes);
 
@@ -244,19 +209,22 @@ async function generateHandler(req: AuthenticatedRequest, res: NextApiResponse):
       generatedPdfs.push(pdfBytes);
     }
 
-    // Only create local directory if not using R2
-    const outputDir = path.join(process.cwd(), 'public', 'generated');
-    if (!storageConfig.isR2Enabled) {
+    const userGeneratedPrefix = `u_${userId}`;
+    // Only create local directories when no cloud provider is active.
+    const outputDir = getGeneratedDir();
+    if (!storageConfig.isR2Enabled && !storageConfig.isS3Enabled) {
       await fsPromises.mkdir(outputDir, { recursive: true });
     }
 
     if (mode === 'individual') {
       // Generate individual PDFs
       const timestamp = Date.now();
-      const sessionDir = path.join(outputDir, `individual_${timestamp}`);
+      const sessionName = `individual_${timestamp}`;
+      const relativeSessionDir = `${userGeneratedPrefix}/${sessionName}`;
+      const sessionDir = path.join(outputDir, relativeSessionDir);
       
       // Only create local directory if not using R2
-      if (!storageConfig.isR2Enabled) {
+      if (!storageConfig.isR2Enabled && !storageConfig.isS3Enabled) {
         await fsPromises.mkdir(sessionDir, { recursive: true });
       }
       
@@ -289,15 +257,26 @@ async function generateHandler(req: AuthenticatedRequest, res: NextApiResponse):
         let fileUrl: string;
         
         if (storageConfig.isR2Enabled) {
-          // Upload to R2
-          const r2Key = `generated/individual_${timestamp}/${filename}`;
-          const uploadResult = await uploadToR2(Buffer.from(pdfBytes), r2Key, 'application/pdf', filename);
-          fileUrl = uploadResult.url;
+          await uploadToR2(
+            Buffer.from(pdfBytes),
+            `generated/${relativeSessionDir}/${filename}`,
+            'application/pdf',
+            filename,
+          );
+          fileUrl = storageConfig.getFileUrl(filename, relativeSessionDir);
+        } else if (storageConfig.isS3Enabled) {
+          await uploadToS3(
+            Buffer.from(pdfBytes),
+            `generated/${relativeSessionDir}/${filename}`,
+            'application/pdf',
+            filename,
+          );
+          fileUrl = storageConfig.getFileUrl(filename, relativeSessionDir);
         } else {
           // Save locally
           const filePath = path.join(sessionDir, filename);
           await fsPromises.writeFile(filePath, pdfBytes);
-          fileUrl = storageConfig.getFileUrl(filename, `individual_${timestamp}`);
+          fileUrl = storageConfig.getFileUrl(filename, relativeSessionDir);
         }
         
         return {
@@ -324,17 +303,22 @@ async function generateHandler(req: AuthenticatedRequest, res: NextApiResponse):
 
       const pdfBytes = await mergedPdf.save();
       const outputFilename = `certificates_${Date.now()}.pdf`;
+      const relativeOutputPath = `${userGeneratedPrefix}/${outputFilename}`;
       let fileUrl: string;
       
       if (storageConfig.isR2Enabled) {
-        // Upload to R2
-        const uploadResult = await uploadToR2(Buffer.from(pdfBytes), `generated/${outputFilename}`, 'application/pdf', outputFilename);
-        fileUrl = uploadResult.url;
+        await uploadToR2(Buffer.from(pdfBytes), `generated/${relativeOutputPath}`, 'application/pdf', outputFilename);
+        fileUrl = storageConfig.getFileUrl(outputFilename, userGeneratedPrefix);
+      } else if (storageConfig.isS3Enabled) {
+        await uploadToS3(Buffer.from(pdfBytes), `generated/${relativeOutputPath}`, 'application/pdf', outputFilename);
+        fileUrl = storageConfig.getFileUrl(outputFilename, userGeneratedPrefix);
       } else {
         // Save locally
-        const outputPath = path.join(outputDir, outputFilename);
+        const userOutputDir = path.join(outputDir, userGeneratedPrefix);
+        await fsPromises.mkdir(userOutputDir, { recursive: true });
+        const outputPath = path.join(userOutputDir, outputFilename);
         await fsPromises.writeFile(outputPath, pdfBytes);
-        fileUrl = storageConfig.getFileUrl(outputFilename);
+        fileUrl = storageConfig.getFileUrl(outputFilename, userGeneratedPrefix);
       }
       
       res.status(200).json({

--- a/pages/api/mark-emailed.ts
+++ b/pages/api/mark-emailed.ts
@@ -1,24 +1,21 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { markAsEmailed, isR2Configured } from '../../lib/r2-client';
-import { markAsEmailedS3, isS3Configured } from '../../lib/s3-client';
+import { requireAuth } from '@/lib/auth/requireAuth';
+import { SignedFileUrlError } from '@/lib/security/signed-generated-url';
+import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> {
+  const session = await requireAuth(req, res);
+  if (!session) return;
+  const userId = (session.user as { id: string }).id;
   if (req.method !== 'POST') {
     res.status(405).json({ error: 'Method not allowed' });
     return;
   }
 
-  // Check which storage provider is configured
   const storageProvider = process.env.STORAGE_PROVIDER || 'local';
-  
-  if (storageProvider === 'local') {
-    // Local storage, skip marking
-    res.status(200).json({ success: true, message: 'Local storage, skipping' });
-    return;
-  }
 
   try {
     const { fileUrl } = req.body;
@@ -28,34 +25,7 @@ export default async function handler(
       return;
     }
 
-    // Handle different storage providers
-    if (storageProvider === 'cloudflare-r2' && isR2Configured()) {
-      // Extract the key from the R2 URL
-      let fileKey: string;
-      
-      if (fileUrl.includes('.r2.cloudflarestorage.com')) {
-        // Direct R2 endpoint URL
-        const urlParts = fileUrl.split('.r2.cloudflarestorage.com/');
-        if (urlParts.length > 1) {
-          fileKey = urlParts[1];
-        } else {
-          throw new Error('Invalid R2 URL format');
-        }
-      } else if (process.env.R2_PUBLIC_URL && fileUrl.startsWith(process.env.R2_PUBLIC_URL)) {
-        // Custom domain URL
-        fileKey = fileUrl.replace(process.env.R2_PUBLIC_URL + '/', '');
-      } else {
-        throw new Error('URL is not an R2 URL');
-      }
-
-      // Mark the file as emailed in R2 metadata
-      await markAsEmailed(fileKey);
-    } else if (storageProvider === 'amazon-s3' && isS3Configured()) {
-      // Mark the file as emailed in S3 metadata
-      await markAsEmailedS3(fileUrl);
-    } else {
-      throw new Error(`Storage provider ${storageProvider} not properly configured`);
-    }
+    await markGeneratedFileAsEmailed(fileUrl, userId);
 
     res.status(200).json({ 
       success: true, 
@@ -65,6 +35,10 @@ export default async function handler(
     return;
 
   } catch (error) {
+    if (error instanceof SignedFileUrlError) {
+      res.status(error.statusCode).json({ error: error.message });
+      return;
+    }
     console.error('Error marking file as emailed:', error);
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     res.status(500).json({ 

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -6,6 +6,7 @@ import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
 import { getMaxPdfSourceBytes, PdfSourceError } from '@/lib/security/trusted-pdf-source';
+import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
 
 const MAX_BULK_EMAILS = 500;
 const BULK_ATTACHMENT_CONCURRENCY = 4;
@@ -54,6 +55,16 @@ async function withQueueIngestionLock<T>(key: string, operation: () => Promise<T
     if (queueIngestionLocks.get(key) === tail) {
       queueIngestionLocks.delete(key);
     }
+  }
+}
+
+export async function markGeneratedRetentionInBatches(urls: string[], userId: string): Promise<void> {
+  const uniqueUrls = [...new Set(urls)];
+  for (let offset = 0; offset < uniqueUrls.length; offset += BULK_ATTACHMENT_CONCURRENCY) {
+    const batch = uniqueUrls.slice(offset, offset + BULK_ATTACHMENT_CONCURRENCY);
+    await Promise.all(batch.map(url => markGeneratedFileAsEmailed(url, userId).catch(error => {
+      console.warn('Failed to extend generated file retention:', error);
+    })));
   }
 }
 
@@ -257,6 +268,10 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
 
       await queueManager.addToQueue(emailParams);
       queueAttachmentBytes.set(key, totalAttachmentBytes);
+
+      await markGeneratedRetentionInBatches(emailParams
+        .map(email => email.certificateUrl)
+        .filter((url): url is string => Boolean(url)), userId);
 
       // Start processing if not already running
       if (!deferProcessing && !queueManager.isProcessing()) {

--- a/pages/api/send-email.ts
+++ b/pages/api/send-email.ts
@@ -7,6 +7,7 @@ import { enforceRateLimit } from '@/lib/rate-limit';
 import { withFeatureGate } from '@/lib/server/middleware/featureGate';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
 import { PdfSourceError } from '@/lib/security/trusted-pdf-source';
+import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
 
 export const config = {
   api: {
@@ -120,6 +121,12 @@ Important: This download link will expire in 90 days. Please save your certifica
         provider: result.provider 
       });
       return;
+    }
+
+    if (deliveryMethod === 'download' && typeof downloadUrl === 'string') {
+      await markGeneratedFileAsEmailed(downloadUrl, userId).catch(error => {
+        console.warn('Failed to extend generated file retention:', error);
+      });
     }
 
     // Return success with email ID and provider info

--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { IncomingForm, File, Fields, Files } from 'formidable';
 import storageConfig from '@/lib/storage-config';
 import { uploadToR2 } from '@/lib/r2-client';
+import { uploadToS3 } from '@/lib/s3-client';
 import { getTempImagesDir, ensureAllDirectoriesExist, ensureDirectoryExists } from '@/lib/paths';
 import { requireAuth } from '@/lib/auth/requireAuth';
 import { debug, error } from '@/lib/log';
@@ -159,19 +160,29 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       debug('Uploading to R2...');
       
       // Upload original image to R2 for display
-      const uploadResult = await uploadToR2(
+      await uploadToR2(
         Buffer.from(originalImageBytes),
         `temp_images/u_${userId}/${imageName}`,
         mimetype,
         imageName
       );
-      imageUrl = uploadResult.url;
+      imageUrl = storageConfig.getFileUrl(`u_${userId}/${imageName}`, undefined, 'temp_images');
       
       // Also save image locally as backup
       const imageFilepath = path.join(userTempDir, imageName);
       await fsPromises.copyFile(filepath, imageFilepath);
       
       debug('R2 upload successful:', imageUrl);
+    } else if (storageConfig.isS3Enabled) {
+      await uploadToS3(
+        Buffer.from(originalImageBytes),
+        `temp_images/u_${userId}/${imageName}`,
+        mimetype,
+        imageName,
+      );
+      imageUrl = storageConfig.getFileUrl(`u_${userId}/${imageName}`, undefined, 'temp_images');
+      const imageFilepath = path.join(userTempDir, imageName);
+      await fsPromises.copyFile(filepath, imageFilepath);
     } else {
       // Fallback to local storage - always use temp_images for user uploads
       const imageFilepath = path.join(userTempDir, imageName);
@@ -183,7 +194,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     res.status(200).json({
       message: 'Template uploaded successfully',
-      filename: pdfFilename,
+      filename: `u_${userId}/${pdfFilename}`,
       image: imageUrl,
       storageType: storageConfig.isR2Enabled ? 'r2' : storageConfig.isS3Enabled ? 's3' : 'local'
     });

--- a/scripts/cleanup-old-files.js
+++ b/scripts/cleanup-old-files.js
@@ -4,25 +4,45 @@
  * Cleanup script for old generated files
  * 
  * This script removes old files from:
- * - public/generated: PDFs and ZIPs older than 7 days
- * - public/temp_images: Temporary images older than 30 days
+ * - storage/generated: PDFs and ZIPs older than 7 days
+ * - storage/temp_images: Temporary images older than 30 days
  * 
  * EXCLUDED from cleanup:
- * - public/template_images: Certificate templates (permanent storage)
+ * - storage/template_images: Certificate templates (permanent storage)
  */
 
 const fs = require('fs');
 const path = require('path');
 
+const storageRoot = process.env.LOCAL_STORAGE_DIR
+  ? path.resolve(process.env.LOCAL_STORAGE_DIR)
+  : path.join(process.cwd(), 'storage');
+
 // Configuration
 const DIRECTORIES = [
-  { path: 'public/generated', extensions: ['.pdf', '.zip'], daysToKeep: 7 },
-  { path: 'public/temp_images', extensions: ['.png', '.jpg', '.jpeg', '.pdf'], daysToKeep: 30 }
-  // Note: public/template_images is excluded - templates are permanent
+  { path: path.join(storageRoot, 'generated'), extensions: ['.pdf', '.zip'], daysToKeep: 7 },
+  { path: path.join(storageRoot, 'temp_images'), extensions: ['.png', '.jpg', '.jpeg', '.pdf'], daysToKeep: 30 }
+  // Note: storage/template_images is excluded - templates are permanent
 ];
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const VERBOSE = process.argv.includes('--verbose') || DRY_RUN;
+const EXTENDED_RETENTION_SUFFIX = '.retention-90d';
+
+function getRetentionDays(dirConfig, filePath) {
+  if (!filePath.startsWith(path.join(storageRoot, 'generated') + path.sep)) {
+    return dirConfig.daysToKeep;
+  }
+  const relativePath = path.relative(dirConfig.path, filePath);
+  const pathSegments = relativePath.split(path.sep);
+  const isIndividual = pathSegments.some(segment =>
+    segment.startsWith('individual_') || segment.startsWith('progressive_')
+  );
+  const retentionMarker = `${filePath}${EXTENDED_RETENTION_SUFFIX}`;
+  const hasExtendedRetention = fs.existsSync(retentionMarker)
+    && fs.lstatSync(retentionMarker).isFile();
+  return isIndividual || hasExtendedRetention ? 90 : dirConfig.daysToKeep;
+}
 
 function getFileAge(filePath) {
   const stats = fs.statSync(filePath);
@@ -49,39 +69,54 @@ function cleanDirectory(dirConfig) {
     return { deleted: 0, size: 0 };
   }
 
-  console.log(`\nCleaning ${dirPath} (files older than ${daysToKeep} days)...`);
+  console.log(`\nCleaning ${dirPath} (base retention ${daysToKeep} days)...`);
   
-  const files = fs.readdirSync(dirPath);
   let deletedCount = 0;
   let totalSize = 0;
 
-  files.forEach(file => {
-    const filePath = path.join(dirPath, file);
-    
-    // Skip if not a file
-    if (!fs.statSync(filePath).isFile()) return;
-    
-    // Skip if not matching extension
-    const ext = path.extname(file).toLowerCase();
-    if (!extensions.includes(ext)) return;
-    
-    const age = getFileAge(filePath);
-    
-    if (age > daysToKeep) {
-      const size = fs.statSync(filePath).size;
-      
-      if (VERBOSE) {
-        console.log(`  ${DRY_RUN ? '[DRY RUN] Would delete' : 'Deleting'}: ${file} (${age} days old, ${formatBytes(size)})`);
+  const pendingDirectories = [dirPath];
+  while (pendingDirectories.length > 0) {
+    const currentDir = pendingDirectories.pop();
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    entries.forEach(entry => {
+      const filePath = path.join(currentDir, entry.name);
+      // Never follow symlinks while traversing cleanup roots.
+      if (entry.isSymbolicLink()) return;
+      if (entry.isDirectory()) {
+        pendingDirectories.push(filePath);
+        return;
       }
-      
-      if (!DRY_RUN) {
-        fs.unlinkSync(filePath);
+      if (!entry.isFile()) return;
+
+      if (entry.name.endsWith(EXTENDED_RETENTION_SUFFIX)) {
+        const sourceFile = filePath.slice(0, -EXTENDED_RETENTION_SUFFIX.length);
+        if (!fs.existsSync(sourceFile) && getFileAge(filePath) > 90 && !DRY_RUN) {
+          fs.unlinkSync(filePath);
+        }
+        return;
       }
-      
-      deletedCount++;
-      totalSize += size;
-    }
-  });
+
+      const ext = path.extname(entry.name).toLowerCase();
+      if (!extensions.includes(ext)) return;
+
+      const age = getFileAge(filePath);
+      const retentionDays = getRetentionDays(dirConfig, filePath);
+      if (age > retentionDays) {
+        const size = fs.statSync(filePath).size;
+        if (VERBOSE) {
+          const relativeFile = path.relative(dirPath, filePath);
+          console.log(`  ${DRY_RUN ? '[DRY RUN] Would delete' : 'Deleting'}: ${relativeFile} (${age} days old, ${retentionDays}-day retention, ${formatBytes(size)})`);
+        }
+        if (!DRY_RUN) {
+          fs.unlinkSync(filePath);
+          const markerPath = `${filePath}${EXTENDED_RETENTION_SUFFIX}`;
+          if (fs.existsSync(markerPath) && fs.lstatSync(markerPath).isFile()) fs.unlinkSync(markerPath);
+        }
+        deletedCount++;
+        totalSize += size;
+      }
+    });
+  }
 
   console.log(`  ${DRY_RUN ? 'Would delete' : 'Deleted'}: ${deletedCount} files, ${formatBytes(totalSize)} freed`);
   

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -9,18 +9,23 @@ function removeFilesInDirectory(dirPath) {
     return 0;
   }
 
-  const files = fs.readdirSync(dirPath);
   let count = 0;
 
-  files.forEach(file => {
-    const filePath = path.join(dirPath, file);
-    const stat = fs.statSync(filePath);
-    
-    if (stat.isFile()) {
-      fs.unlinkSync(filePath);
-      count++;
-    }
-  });
+  const pendingDirectories = [dirPath];
+  while (pendingDirectories.length > 0) {
+    const currentDir = pendingDirectories.pop();
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    entries.forEach(entry => {
+      const filePath = path.join(currentDir, entry.name);
+      if (entry.isSymbolicLink()) return;
+      if (entry.isDirectory()) {
+        pendingDirectories.push(filePath);
+      } else if (entry.isFile()) {
+        fs.unlinkSync(filePath);
+        count++;
+      }
+    });
+  }
 
   return count;
 }
@@ -29,8 +34,11 @@ function main() {
   console.log('🧹 Cleaning up temporary and generated files...\n');
 
   // Local development directories
-  const localGenerated = path.join(__dirname, '..', 'public', 'generated');
-  const localTempImages = path.join(__dirname, '..', 'public', 'temp_images');
+  const storageRoot = process.env.LOCAL_STORAGE_DIR
+    ? path.resolve(process.env.LOCAL_STORAGE_DIR)
+    : path.join(__dirname, '..', 'storage');
+  const localGenerated = path.join(storageRoot, 'generated');
+  const localTempImages = path.join(storageRoot, 'temp_images');
 
   // Docker volume directories
   const dockerGenerated = path.join(__dirname, '..', 'data', 'generated');

--- a/scripts/migrate-private-storage.js
+++ b/scripts/migrate-private-storage.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+const storageRoot = process.env.LOCAL_STORAGE_DIR
+  ? path.resolve(process.env.LOCAL_STORAGE_DIR)
+  : path.join(root, 'storage');
+const namespaces = ['generated', 'temp_images', 'template_images'];
+const bundledTemplates = new Set(['.gitkeep', 'dev-mode-template.jpg', 'dev-mode-template.pdf']);
+
+function migrateDirectory(sourceDir, destinationDir, namespace) {
+  if (!fs.existsSync(sourceDir)) return 0;
+  fs.mkdirSync(destinationDir, { recursive: true });
+  let migrated = 0;
+
+  const move = (source, destination) => {
+    try {
+      fs.renameSync(source, destination);
+    } catch (error) {
+      if (error.code !== 'EXDEV') throw error;
+      fs.cpSync(source, destination, { recursive: true, errorOnExist: true });
+      fs.rmSync(source, { recursive: true, force: true });
+    }
+  };
+
+  const uniquePrivateConflictPath = destination => {
+    let counter = 1;
+    let candidate = `${destination}.legacy-conflict`;
+    while (fs.existsSync(candidate)) candidate = `${destination}.legacy-conflict-${counter++}`;
+    return candidate;
+  };
+
+  const migrateEntry = (source, destination) => {
+    const sourceStat = fs.lstatSync(source);
+    if (!fs.existsSync(destination)) {
+      move(source, destination);
+      migrated += 1;
+      return;
+    }
+
+    const destinationStat = fs.lstatSync(destination);
+    if (sourceStat.isDirectory() && destinationStat.isDirectory()) {
+      for (const child of fs.readdirSync(source)) {
+        migrateEntry(path.join(source, child), path.join(destination, child));
+      }
+      if (fs.readdirSync(source).length === 0) fs.rmdirSync(source);
+      return;
+    }
+
+    // Never leave a collision in public storage. Preserve it under a unique,
+    // private conflict name for operator inspection rather than overwriting.
+    move(source, uniquePrivateConflictPath(destination));
+    migrated += 1;
+  };
+
+  for (const entry of fs.readdirSync(sourceDir, { withFileTypes: true })) {
+    if (namespace === 'template_images' && bundledTemplates.has(entry.name)) continue;
+    const source = path.join(sourceDir, entry.name);
+    const destination = path.join(destinationDir, entry.name);
+    migrateEntry(source, destination);
+  }
+  return migrated;
+}
+
+function main() {
+  let migrated = 0;
+  for (const namespace of namespaces) {
+    migrated += migrateDirectory(
+      path.join(root, 'public', namespace),
+      path.join(storageRoot, namespace),
+      namespace,
+    );
+  }
+  console.log(`Private storage migration complete (${migrated} entries moved).`);
+}
+
+if (require.main === module) main();
+
+module.exports = { main, migrateDirectory };


### PR DESCRIPTION
## Summary
- move uploaded and generated user files out of the public web root into private, user-scoped storage
- issue HMAC-signed download capabilities and enforce ownership for local/R2/S3 delivery, email retention, templates, and progressive sessions
- migrate legacy local storage safely and update Docker volumes/cleanup/admin tooling
- bound cloud retention rewrites and stream private local/admin downloads with path and symlink confinement

## Verification
- `npm test -- --runInBand --silent` (60 suites, 538 passed, 1 skipped)
- `npm run build`
- clean-context Docker image build and runner `prestart` migration
- live signed-download checks: valid stream, unsigned rejection, tamper rejection
- Claude adversarial review: CLEAN
- ultra subagent adversarial review: CLEAN

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->