### PR TITLE
Reduce drag-time render overhead

### DIFF
--- a/__tests__/components/CertificatePreview.memo.test.ts
+++ b/__tests__/components/CertificatePreview.memo.test.ts
@@ -1,0 +1,81 @@
+import { areCertificatePreviewPropsEqual } from '@/components/CertificatePreview';
+import type { CertificatePreviewProps } from '@/types/certificate';
+
+const createProps = (): CertificatePreviewProps => {
+  const row = { name: 'Ada' };
+  return {
+    uploadedFileUrl: '/certificate.png',
+    isLoading: false,
+    tableData: [row, { name: 'Grace' }],
+    currentPreviewIndex: 0,
+    positions: { name: { x: 50, y: 50, fontSize: 20 } },
+    selectedField: 'name',
+    setSelectedField: jest.fn(),
+    isDragging: false,
+    dragInfo: null,
+    showCenterGuide: { horizontal: false, vertical: false },
+    handlePointerDown: jest.fn(),
+    handlePointerUp: jest.fn(),
+    setShowCenterGuide: jest.fn(),
+    isDraggingFile: false,
+    handleDragOver: jest.fn(),
+    handleDragLeave: jest.fn(),
+    handleFileDrop: jest.fn(),
+    handleFileUpload: jest.fn()
+  };
+};
+
+describe('CertificatePreview memo comparison', () => {
+  it('uses immutable references instead of serializing positions and rows', () => {
+    const previous = createProps();
+    const next = { ...previous, tableData: [...previous.tableData] };
+
+    expect(areCertificatePreviewPropsEqual(previous, next)).toBe(true);
+    expect(
+      areCertificatePreviewPropsEqual(previous, {
+        ...next,
+        positions: { ...previous.positions }
+      })
+    ).toBe(false);
+    expect(
+      areCertificatePreviewPropsEqual(previous, {
+        ...next,
+        tableData: [{ ...previous.tableData[0] }, previous.tableData[1]]
+      })
+    ).toBe(false);
+  });
+
+  it('ignores changes to rows outside the active preview', () => {
+    const previous = createProps();
+    const next = {
+      ...previous,
+      tableData: [previous.tableData[0], { name: 'Katherine' }]
+    };
+
+    expect(areCertificatePreviewPropsEqual(previous, next)).toBe(true);
+  });
+
+  it('compares drag state and the rendered fallback row', () => {
+    const previous = createProps();
+    const dragging = {
+      ...previous,
+      isDragging: true,
+      dragInfo: { key: 'name', offsetX: 0, offsetY: 0, pointerId: 1 }
+    };
+
+    expect(
+      areCertificatePreviewPropsEqual(dragging, {
+        ...dragging,
+        dragInfo: { ...dragging.dragInfo, key: 'title' }
+      })
+    ).toBe(false);
+
+    const outOfRange = { ...previous, currentPreviewIndex: 10 };
+    expect(
+      areCertificatePreviewPropsEqual(outOfRange, {
+        ...outOfRange,
+        tableData: [{ name: 'Changed' }, previous.tableData[1]]
+      })
+    ).toBe(false);
+  });
+});

--- a/__tests__/hooks/useDragAndDrop.test.ts
+++ b/__tests__/hooks/useDragAndDrop.test.ts
@@ -1,0 +1,25 @@
+import { updatePositionIfChanged } from '@/hooks/useDragAndDrop';
+import type { Positions } from '@/types/certificate';
+
+describe('updatePositionIfChanged', () => {
+  it('preserves the positions reference when drag coordinates are unchanged', () => {
+    const positions: Positions = {
+      name: { x: 50, y: 50, fontSize: 20 }
+    };
+
+    expect(updatePositionIfChanged(positions, 'name', 50, 50)).toBe(positions);
+  });
+
+  it('updates only the moved field while preserving its formatting', () => {
+    const positions: Positions = {
+      name: { x: 50, y: 50, fontSize: 20 },
+      title: { x: 40, y: 30, bold: true }
+    };
+
+    const updated = updatePositionIfChanged(positions, 'name', 52, 48);
+
+    expect(updated).not.toBe(positions);
+    expect(updated.name).toEqual({ x: 52, y: 48, fontSize: 20 });
+    expect(updated.title).toBe(positions.title);
+  });
+});

--- a/components/CertificatePreview.tsx
+++ b/components/CertificatePreview.tsx
@@ -465,7 +465,15 @@ function CertificatePreviewComponent({
 }
 
 // Memoize the component to prevent unnecessary re-renders
-export const CertificatePreview = React.memo(CertificatePreviewComponent, (prevProps, nextProps) => {
+export const areCertificatePreviewPropsEqual = (
+  prevProps: CertificatePreviewProps,
+  nextProps: CertificatePreviewProps
+) => {
+  const previousRow =
+    prevProps.tableData[prevProps.currentPreviewIndex] || prevProps.tableData[0];
+  const nextRow =
+    nextProps.tableData[nextProps.currentPreviewIndex] || nextProps.tableData[0];
+
   // Only re-render if these specific props change
   return (
     prevProps.uploadedFileUrl === nextProps.uploadedFileUrl &&
@@ -473,12 +481,23 @@ export const CertificatePreview = React.memo(CertificatePreviewComponent, (prevP
     prevProps.currentPreviewIndex === nextProps.currentPreviewIndex &&
     prevProps.selectedField === nextProps.selectedField &&
     prevProps.isDragging === nextProps.isDragging &&
+    prevProps.dragInfo === nextProps.dragInfo &&
     prevProps.isDraggingFile === nextProps.isDraggingFile &&
     prevProps.showCenterGuide === nextProps.showCenterGuide &&
-    // Deep comparison for positions (only for the current preview)
-    JSON.stringify(prevProps.positions) === JSON.stringify(nextProps.positions) &&
-    // Deep comparison for current table data only
-    JSON.stringify(prevProps.tableData[prevProps.currentPreviewIndex]) === 
-    JSON.stringify(nextProps.tableData[nextProps.currentPreviewIndex])
+    prevProps.positions === nextProps.positions &&
+    previousRow === nextRow &&
+    prevProps.setSelectedField === nextProps.setSelectedField &&
+    prevProps.handlePointerDown === nextProps.handlePointerDown &&
+    prevProps.handlePointerUp === nextProps.handlePointerUp &&
+    prevProps.setShowCenterGuide === nextProps.setShowCenterGuide &&
+    prevProps.handleDragOver === nextProps.handleDragOver &&
+    prevProps.handleDragLeave === nextProps.handleDragLeave &&
+    prevProps.handleFileDrop === nextProps.handleFileDrop &&
+    prevProps.handleFileUpload === nextProps.handleFileUpload
   );
-});
+};
+
+export const CertificatePreview = React.memo(
+  CertificatePreviewComponent,
+  areCertificatePreviewPropsEqual
+);

--- a/hooks/useDragAndDrop.ts
+++ b/hooks/useDragAndDrop.ts
@@ -19,6 +19,21 @@ export interface UseDragAndDropReturn {
   clearDragState: () => void;
 }
 
+export function updatePositionIfChanged(
+  positions: Positions,
+  key: string,
+  x: number,
+  y: number
+): Positions {
+  const current = positions[key];
+  if (current?.x === x && current.y === y) return positions;
+
+  return {
+    ...positions,
+    [key]: { ...current, x, y }
+  };
+}
+
 export function useDragAndDrop({
   positions,
   setPositions,
@@ -34,13 +49,19 @@ export function useDragAndDrop({
 
   // Throttled position update for 60fps (16ms)
   const updatePosition = useCallback((key: string, x: number, y: number) => {
-    setPositions((prev) => ({
-      ...prev,
-      [key]: { ...prev[key], x, y }
-    }));
+    setPositions((prev) => updatePositionIfChanged(prev, key, x, y));
   }, [setPositions]);
 
   const throttledUpdatePosition = useThrottle(updatePosition, 16);
+
+  const updateCenterGuide = useCallback((next: CenterGuideState) => {
+    setShowCenterGuide((current) =>
+      current.horizontal === next.horizontal &&
+      current.vertical === next.vertical
+        ? current
+        : next
+    );
+  }, []);
 
   // Global pointer event handlers for smooth dragging
   useEffect(() => {
@@ -70,11 +91,9 @@ export function useDragAndDrop({
           y < -threshold ||
           y > 100 + threshold
         ) {
-          // If dragged too far, reset to center but preserve other properties
-          setPositions((prev) => ({
-            ...prev,
-            [dragInfo.key]: { ...prev[dragInfo.key], x: 50, y: 50 }
-          }));
+          // If dragged too far, reset to center through the same frame throttle.
+          updateCenterGuide({ horizontal: false, vertical: false });
+          throttledUpdatePosition(dragInfo.key, 50, 50);
         } else {
           // Clamp the values between 0 and 100 but preserve other properties
           let clampedX = Math.max(0, Math.min(100, x));
@@ -98,7 +117,7 @@ export function useDragAndDrop({
           }
 
           // Show/hide center guides based on which axis is snapping
-          setShowCenterGuide({
+          updateCenterGuide({
             horizontal: isSnappingHorizontal,
             vertical: isSnappingVertical
           });
@@ -128,7 +147,7 @@ export function useDragAndDrop({
         document.removeEventListener("pointercancel", handleGlobalPointerUp);
       };
     }
-  }, [isDragging, dragInfo, throttledUpdatePosition]);
+  }, [isDragging, dragInfo, throttledUpdatePosition, updateCenterGuide]);
 
   // Cleanup drag state on unmount
   useEffect(() => {

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -980,15 +980,23 @@ export default function HomePage() {
       </main>
 
       {/* Modal Components */}
-      <PdfGenerationModal
-        isGenerating={isGenerating}
-        generatedPdfUrl={generatedPdfUrl}
-        handleDownloadPdf={handleDownloadPdf}
-        setGeneratedPdfUrl={setGeneratedPdfUrl}
-        onClose={() => setGeneratedPdfUrl(null)}
-      />
+      {(isGenerating || generatedPdfUrl) && (
+        <PdfGenerationModal
+          isGenerating={isGenerating}
+          generatedPdfUrl={generatedPdfUrl}
+          handleDownloadPdf={handleDownloadPdf}
+          setGeneratedPdfUrl={setGeneratedPdfUrl}
+          onClose={() => setGeneratedPdfUrl(null)}
+        />
+      )}
 
-      <IndividualPdfsModal
+      {(isGeneratingIndividual ||
+        isProgressiveGenerating ||
+        isClientGeneratingIndividual ||
+        !!individualPdfsData ||
+        !!clientIndividualPdfsData ||
+        !!progressivePdfProgress) && (
+        <IndividualPdfsModal
         isGeneratingIndividual={
           isGeneratingIndividual || isProgressiveGenerating || isClientGeneratingIndividual
         }
@@ -1028,22 +1036,26 @@ export default function HomePage() {
             clearClientPdfData();
           }
         }}
-      />
+        />
+      )}
 
-      <ConfirmationModals
-        showResetFieldModal={showResetFieldModal}
-        setShowResetFieldModal={setShowResetFieldModal}
-        showClearAllModal={showClearAllModal}
-        setShowClearAllModal={setShowClearAllModal}
-        selectedField={selectedField}
-        positions={positions}
-        setPositions={setPositions}
-        tableData={tableData}
-        automaticTextColor={automaticTextColor}
-      />
+      {(showResetFieldModal || showClearAllModal) && (
+        <ConfirmationModals
+          showResetFieldModal={showResetFieldModal}
+          setShowResetFieldModal={setShowResetFieldModal}
+          showClearAllModal={showClearAllModal}
+          setShowClearAllModal={setShowClearAllModal}
+          selectedField={selectedField}
+          positions={positions}
+          setPositions={setPositions}
+          tableData={tableData}
+          automaticTextColor={automaticTextColor}
+        />
+      )}
 
       {/* Project Modals */}
-      <SaveProjectModal
+      {showSaveProjectModal && (
+        <SaveProjectModal
         isOpen={showSaveProjectModal}
         onClose={() => setShowSaveProjectModal(false)}
         positions={positions}
@@ -1075,22 +1087,27 @@ export default function HomePage() {
           }
           return baseManualSave(projectName, finalUrl ?? undefined, finalFilename ?? undefined);
         }}
-      />
+        />
+      )}
 
-      <LoadProjectModal
-        isOpen={showLoadProjectModal}
-        onClose={() => setShowLoadProjectModal(false)}
-        onLoadProject={handleLoadProject}
-      />
+      {showLoadProjectModal && (
+        <LoadProjectModal
+          isOpen
+          onClose={() => setShowLoadProjectModal(false)}
+          onLoadProject={handleLoadProject}
+        />
+      )}
 
-      <NewProjectModal
-        isOpen={showNewProjectModal}
-        onClose={() => setShowNewProjectModal(false)}
-        onConfirm={confirmNewProject}
-        hasUnsavedWork={
-          uploadedFileUrl !== null && Object.keys(positions || {}).length > 0
-        }
-      />
+      {showNewProjectModal && (
+        <NewProjectModal
+          isOpen
+          onClose={() => setShowNewProjectModal(false)}
+          onConfirm={confirmNewProject}
+          hasUnsavedWork={
+            uploadedFileUrl !== null && Object.keys(positions || {}).length > 0
+          }
+        />
+      )}
 
       {/* Toast Container */}
       <ToastContainer toasts={toasts} onClose={hideToast} />
@@ -1113,21 +1130,23 @@ export default function HomePage() {
 
 
       {/* Onboarding Modal */}
-      <OnboardingModal
-        isOpen={showOnboarding}
-        onClose={() => setShowOnboarding(false)}
-        onStartTour={() => {
-          setShowOnboarding(false);
-          // Small delay to ensure modal is closed before starting tour
-          setTimeout(() => {
-            startTour();
-          }, 300);
-        }}
-        onSkip={() => {
-          setShowOnboarding(false);
-          skipOnboarding();
-        }}
-      />
+      {showOnboarding && (
+        <OnboardingModal
+          isOpen
+          onClose={() => setShowOnboarding(false)}
+          onStartTour={() => {
+            setShowOnboarding(false);
+            // Small delay to ensure modal is closed before starting tour
+            setTimeout(() => {
+              startTour();
+            }, 300);
+          }}
+          onSkip={() => {
+            setShowOnboarding(false);
+            skipOnboarding();
+          }}
+        />
+      )}
 
       {/* Dev Mode Footer - Visible in development OR for super admins */}
       <DevModeFooter


### PR DESCRIPTION
## Summary
- prevent no-op center-guide and position state updates during pointer movement
- throttle out-of-bounds resets through the same 60 fps path
- replace JSON serialization in the preview memo comparator with complete immutable-reference checks
- avoid mounting expensive modal trees and localStorage scans while closed

## Verification
- `npm test -- --runInBand __tests__/hooks/useDragAndDrop.test.ts __tests__/components/CertificatePreview.memo.test.ts`
- `npm run build`
- `npm run lint` (passes with pre-existing warnings)
- ultra adversarial review: clean after three findings resolved
- `claude -p`: repeatedly requested; local CLI timed out without output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->