### PR TITLE
security: authorize project updates before mutation

### DIFF
--- a/__tests__/api/projects.test.ts
+++ b/__tests__/api/projects.test.ts
@@ -53,12 +53,43 @@ describe('projects API', () => {
     expect(json.projects[1]).toMatchObject({ columnsCount: 1, rowsCount: 0 });
   });
 
-  it('prevents updating a project not owned by user', async () => {
+  it('does not mutate a project not owned by the user', async () => {
     requireAuth.mockResolvedValue({ user: { id: 'u1' } });
-    prisma.project.update.mockResolvedValue({ id: 'p1', ownerId: 'other', name: 'N', data: {} });
+    prisma.project.update.mockRejectedValue({ code: 'P2025' });
     const req = httpMocks.createRequest({ method: 'PUT', query: { id: 'p1' }, body: { name: 'New', data: {} } });
     const res = httpMocks.createResponse();
     await handlerItem(req as any, res as any);
-    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).toBe(404);
+    expect(prisma.project.update).toHaveBeenCalledWith({
+      where: { id: 'p1', ownerId: 'u1' },
+      data: { name: 'New', data: {} },
+    });
+  });
+
+  it('returns the updated project after an owner-scoped update', async () => {
+    requireAuth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.project.update.mockResolvedValue({ id: 'p1', ownerId: 'u1', name: 'New', data: {} });
+    const req = httpMocks.createRequest({ method: 'PUT', query: { id: 'p1' }, body: { name: 'New', data: {} } });
+    const res = httpMocks.createResponse();
+
+    await handlerItem(req as any, res as any);
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getJSONData().project).toMatchObject({ id: 'p1', ownerId: 'u1', name: 'New' });
+  });
+
+  it('does not delete a project not owned by the user', async () => {
+    requireAuth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.project.delete.mockRejectedValue({ code: 'P2025' });
+    const req = httpMocks.createRequest({ method: 'DELETE', query: { id: 'p1' } });
+    const res = httpMocks.createResponse();
+
+    await handlerItem(req as any, res as any);
+
+    expect(res.statusCode).toBe(404);
+    expect(prisma.project.delete).toHaveBeenCalledWith({
+      where: { id: 'p1', ownerId: 'u1' },
+    });
+    expect(prisma.project.findUnique).not.toHaveBeenCalled();
   });
 });

--- a/pages/api/projects/[id].ts
+++ b/pages/api/projects/[id].ts
@@ -21,10 +21,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const { name, data } = req.body ?? {};
     try {
       const updated = await prisma.project.update({
-        where: { id },
+        where: { id, ownerId: userId },
         data: { name: name ? String(name).trim() : undefined, data: data ?? undefined },
       });
-      if (updated.ownerId !== userId) { res.status(403).json({ error: 'Forbidden' }); return; }
       res.status(200).json({ project: updated });
       return;
     } catch (e: any) {
@@ -38,12 +37,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'DELETE') {
     try {
-      const existing = await prisma.project.findUnique({ where: { id } });
-      if (!existing || existing.ownerId !== userId) { res.status(404).json({ error: 'Not found' }); return; }
-      await prisma.project.delete({ where: { id } });
+      await prisma.project.delete({ where: { id, ownerId: userId } });
       res.status(204).end();
       return;
-    } catch (e) {
+    } catch (e: any) {
+      if (e?.code === 'P2025') { res.status(404).json({ error: 'Not found' }); return; }
       console.error('Delete project error:', e);
       res.status(500).json({ error: 'Failed to delete project' });
       return;


### PR DESCRIPTION
## Summary
- enforce project ownership inside the atomic Prisma update predicate
- return the same 404 for missing and non-owned project IDs
- add regression coverage proving a non-owner write cannot occur

## Verification
- `npm test -- --runInBand --silent __tests__/api/projects.test.ts`
- `npm run build`
- `npm run lint`
- Claude adversarial review: CLEAN
- ultra subagent adversarial review: CLEAN

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->