### PR TITLE
Release completed email queue payloads

### DIFF
--- a/__tests__/api/send-bulk-email.test.ts
+++ b/__tests__/api/send-bulk-email.test.ts
@@ -177,6 +177,91 @@ describe('/api/send-bulk-email', () => {
     expect(data.total).toBe(0);
   });
 
+  it('releases completed queue items after returning their terminal status', async () => {
+    const post = createMocks({
+      method: 'POST',
+      body: {
+        emails: [{ to: 'done@example.com', subject: 'Test', html: 'Test' }],
+        config: { senderName: 'Test', subject: 'Test', message: 'Test' },
+        sessionId: 'completed-session',
+        deferProcessing: true
+      }
+    });
+    await handler(post.req, post.res);
+
+    const queueModule = jest.requireMock('@/lib/email/email-queue');
+    const queue = queueModule.EmailQueueManager.mock.results.at(-1).value;
+    queue.getStatus.mockReturnValue({
+      status: 'completed',
+      processed: 1,
+      failed: 0,
+      total: 1,
+      remaining: 0
+    });
+
+    const firstTerminal = createMocks({
+      method: 'GET',
+      query: { sessionId: 'completed-session' }
+    });
+    const overlappingTerminal = createMocks({
+      method: 'GET',
+      query: { sessionId: 'completed-session' }
+    });
+    await Promise.all([
+      handler(firstTerminal.req, firstTerminal.res),
+      handler(overlappingTerminal.req, overlappingTerminal.res)
+    ]);
+
+    expect(JSON.parse(firstTerminal.res._getData())).toMatchObject({
+      status: 'completed',
+      processed: 1,
+      total: 1
+    });
+    expect(JSON.parse(overlappingTerminal.res._getData())).toMatchObject({
+      status: 'completed',
+      processed: 1,
+      total: 1
+    });
+    expect(queue.clear).toHaveBeenCalledTimes(1);
+
+    const afterCleanup = createMocks({
+      method: 'GET',
+      query: { sessionId: 'completed-session' }
+    });
+    await handler(afterCleanup.req, afterCleanup.res);
+    expect(JSON.parse(afterCleanup.res._getData())).toMatchObject({
+      status: 'completed',
+      processed: 1,
+      total: 1
+    });
+  });
+
+  it('preserves all valid recipients from a mixed recipient cell', async () => {
+    const post = createMocks({
+      method: 'POST',
+      body: {
+        emails: [{
+          to: 'first@example.com, invalid, second@example.com',
+          subject: 'Test',
+          html: 'Test'
+        }],
+        config: { senderName: 'Test', subject: 'Test', message: 'Test' },
+        sessionId: 'mixed-recipient-session',
+        deferProcessing: true
+      }
+    });
+
+    await handler(post.req, post.res);
+
+    const queueModule = jest.requireMock('@/lib/email/email-queue');
+    const queue = queueModule.EmailQueueManager.mock.results.at(-1).value;
+    expect(queue.addToQueue).toHaveBeenCalledWith([
+      expect.objectContaining({
+        to: ['first@example.com', 'second@example.com']
+      })
+    ]);
+  });
+
   it('clears stale processing queues and their retained state', async () => {
     const post = createMocks({
       method: 'POST',

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -14,6 +14,8 @@ const DEFAULT_MAX_BULK_ATTACHMENT_BYTES = 100 * 1024 * 1024;
 const HARD_MAX_BULK_ATTACHMENT_BYTES = 250 * 1024 * 1024;
 const ACTIVE_QUEUE_TTL_MS = 3600000;
 const PAUSED_QUEUE_TTL_MS = 24 * ACTIVE_QUEUE_TTL_MS;
+const TERMINAL_STATUS_TTL_MS = 10 * 60 * 1000;
+const MAX_TERMINAL_STATUSES = 200;
 const DEFAULT_MAX_PAUSED_ATTACHMENT_BYTES = HARD_MAX_BULK_ATTACHMENT_BYTES;
 const PAUSED_PRESSURE_LOCK = '__global_paused_queue_pressure__';
 
@@ -48,9 +50,37 @@ export const config = {
 const queueManagers = new Map<string, EmailQueueManager>();
 const queueAttachmentBytes = new Map<string, number>();
 const queueIngestionLocks = new Map<string, Promise<void>>();
+type QueueStatus = ReturnType<EmailQueueManager['getStatus']>;
+const terminalQueueStatuses = new Map<
+  string,
+  { status: QueueStatus; expiresAt: number }
+>();
 
 function queueKey(userId: string, sessionId: string): string {
   return `${userId}:${sessionId}`;
+}
+
+function rememberTerminalStatus(key: string, status: QueueStatus): void {
+  terminalQueueStatuses.delete(key);
+  while (terminalQueueStatuses.size >= MAX_TERMINAL_STATUSES) {
+    const oldestKey = terminalQueueStatuses.keys().next().value;
+    if (oldestKey === undefined) break;
+    terminalQueueStatuses.delete(oldestKey);
+  }
+  terminalQueueStatuses.set(key, {
+    status,
+    expiresAt: Date.now() + TERMINAL_STATUS_TTL_MS
+  });
+}
+
+function getTerminalStatus(key: string, now = Date.now()): QueueStatus | null {
+  const terminal = terminalQueueStatuses.get(key);
+  if (!terminal) return null;
+  if (terminal.expiresAt <= now) {
+    terminalQueueStatuses.delete(key);
+    return null;
+  }
+  return terminal.status;
 }
 
 async function withQueueIngestionLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
@@ -153,6 +183,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     const key = queueKey(userId, sessionId);
     let successPayload: Record<string, unknown> | null = null;
     await withQueueIngestionLock(key, async () => {
+      terminalQueueStatuses.delete(key);
       // Get or create queue manager for this session
       let queueManager = queueManagers.get(key);
       if (!queueManager) {
@@ -341,8 +372,27 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse): Promise<voi
       return;
     }
 
-    const queueManager = userId ? queueManagers.get(queueKey(userId, sessionId)) : undefined;
-    if (!queueManager) {
+    const key = userId ? queueKey(userId, sessionId) : '';
+    let status: QueueStatus | null = null;
+    if (key) {
+      await withQueueIngestionLock(key, async () => {
+        const queueManager = queueManagers.get(key);
+        if (!queueManager) {
+          status = getTerminalStatus(key);
+          return;
+        }
+
+        status = queueManager.getStatus();
+        if (status.status === 'completed') {
+          rememberTerminalStatus(key, status);
+          await queueManager.clear();
+          queueManagers.delete(key);
+          queueAttachmentBytes.delete(key);
+        }
+      });
+    }
+
+    if (!status) {
       res.status(200).json({
         status: 'idle',
         processed: 0,
@@ -353,7 +403,6 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse): Promise<voi
       return;
     }
 
-    const status = queueManager.getStatus();
     res.status(200).json(status);
     return;
   } catch (error) {
@@ -394,6 +443,10 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
     await withQueueIngestionLock(key, async () => {
       const queueManager = queueManagers.get(key);
       if (!queueManager) {
+        if (action === 'cancel' && terminalQueueStatuses.delete(key)) {
+          actionSucceeded = true;
+          return;
+        }
         res.status(404).json({ error: 'No active queue found' });
         return;
       }
@@ -410,6 +463,7 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
         await queueManager.clear();
         queueManagers.delete(key);
         queueAttachmentBytes.delete(key);
+        terminalQueueStatuses.delete(key);
       } else {
         res.status(400).json({ error: 'Invalid action' });
         return;
@@ -485,6 +539,9 @@ export async function cleanupExpiredEmailQueues(now = Date.now()): Promise<void>
       queueAttachmentBytes.delete(key);
     })
   ));
+  for (const [key, terminal] of terminalQueueStatuses) {
+    if (terminal.expiresAt <= now) terminalQueueStatuses.delete(key);
+  }
   await enforcePausedAttachmentLimit();
 }
 


### PR DESCRIPTION
## Summary
- release completed queue items and attachment byte accounting on the first terminal status poll
- retain a lightweight user-scoped terminal status tombstone for stable concurrent/retried polling
- bound tombstones to 200 entries and 10 minutes, with cleanup on reuse, cancel, and periodic expiry
- confirm mixed recipient cells preserve every valid address

## Verification
- `npm test -- --runInBand __tests__/api/send-bulk-email.test.ts __tests__/components/modals/BulkEmailModal.test.tsx`
- `npm run build`
- ultra adversarial review: clean after one-shot terminal status race resolved
- `claude -p`: repeatedly requested; local CLI timed out without output
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->