### PR TITLE
security: enforce email quotas and trusted content

### DIFF
--- a/__tests__/api/send-bulk-email-attachment-limits.test.ts
+++ b/__tests__/api/send-bulk-email-attachment-limits.test.ts
@@ -28,6 +28,12 @@ jest.mock('@/lib/auth/requireAuth', () => ({
 jest.mock('@/lib/rate-limit', () => ({
   enforceRateLimit: jest.fn(() => ({ allowed: true }))
 }));
+jest.mock('@/lib/server/tiers', () => ({
+  checkEmailUsageAvailability: jest.fn(async () => ({ allowed: true, limit: 100, current: 0 })),
+  reserveEmailUsage: jest.fn(async (_userId: string, count: number) => ({
+    allowed: true, limit: 100, current: count
+  }))
+}));
 jest.mock('../../utils/email-utils', () => {
   const actual = jest.requireActual('../../utils/email-utils');
   return { ...actual, buildPdfAttachments: jest.fn() };

--- a/__tests__/api/send-bulk-email-quota.test.ts
+++ b/__tests__/api/send-bulk-email-quota.test.ts
@@ -1,0 +1,151 @@
+/** @jest-environment node */
+
+const addToQueue = jest.fn(async () => undefined);
+jest.mock('@/lib/email/email-queue', () => ({
+  EmailQueueManager: jest.fn(() => ({
+    addToQueue,
+    isProcessing: jest.fn(() => true),
+    processQueue: jest.fn(),
+    getQueueLength: jest.fn(() => 0),
+    getStatus: jest.fn(() => ({ status: 'idle' })),
+    getLastActivity: jest.fn(() => Date.now()),
+    clear: jest.fn(),
+  })),
+}));
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(async () => ({ user: { id: 'u1' } })),
+}));
+jest.mock('@/lib/email/provider-factory', () => ({
+  getEmailProvider: jest.fn(() => ({ name: 'resend' })),
+}));
+jest.mock('@/lib/server/tiers', () => ({
+  checkEmailUsageAvailability: jest.fn(async () => ({ allowed: true, limit: 100, current: 0 })),
+  reserveEmailUsage: jest.fn(async () => ({ allowed: true, limit: 100, current: 2 })),
+}));
+jest.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: jest.fn(() => ({ allowed: true })),
+}));
+jest.mock('@/lib/storage/mark-generated', () => ({
+  markGeneratedFileAsEmailed: jest.fn(async () => undefined),
+}));
+
+import httpMocks from 'node-mocks-http';
+import handler, { cleanupEmailQueueInterval } from '@/pages/api/send-bulk-email';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+import { reserveEmailUsage } from '@/lib/server/tiers';
+
+const mockReserveEmailUsage = reserveEmailUsage as jest.MockedFunction<typeof reserveEmailUsage>;
+
+describe('bulk email quota and content controls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+  });
+  afterAll(() => cleanupEmailQueueInterval());
+  afterEach(() => delete process.env.FILE_URL_SIGNING_SECRET);
+
+  it('counts actual recipients and ignores client-supplied HTML', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        emails: [{
+          to: 'one@example.com,two@example.com',
+          subject: 'Attacker subject',
+          html: '<a href="https://evil.example">phish</a>',
+          certificateUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+        }],
+        config: { senderName: 'Trainer', subject: 'Certificate', message: '<b>Hello</b>' },
+        sessionId: 'email-session-test',
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockReserveEmailUsage).toHaveBeenCalledWith('u1', 2);
+    const queued = addToQueue.mock.calls[0][0][0];
+    expect(queued.subject).toBe('Certificate');
+    expect(queued.html).toContain('&lt;b&gt;Hello&lt;/b&gt;');
+    expect(queued.html).not.toContain('evil.example');
+  });
+
+  it('does not enqueue when quota reservation is denied', async () => {
+    mockReserveEmailUsage.mockResolvedValueOnce({ allowed: false, limit: 0, current: 0 });
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        emails: [{
+          to: 'victim@example.com',
+          certificateUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+        }],
+        config: { senderName: 'Trainer', subject: 'Certificate', message: 'Hello' },
+        sessionId: 'email-session-denied',
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(addToQueue).not.toHaveBeenCalled();
+  });
+
+  it('does not treat malformed empty attachment data as trusted link delivery', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        emails: [{
+          to: 'victim@example.com',
+          attachmentData: {},
+          certificateUrl: 'https://evil.example/phish',
+        }],
+        config: { senderName: 'Trainer', subject: 'Certificate', message: 'Hello' },
+        sessionId: 'email-session-empty-attachment',
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(addToQueue).not.toHaveBeenCalled();
+  });
+
+  it('enforces the recipient cap cumulatively across deferred batches', async () => {
+    const recipients = (start: number, count: number) =>
+      Array.from({ length: count }, (_, index) => `user${start + index}@example.com`).join(',');
+    const firstEmails = Array.from({ length: 50 }, (_, index) => ({
+      to: recipients(index * 10, 10),
+      certificateUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+    }));
+    const first = httpMocks.createMocks({
+      method: 'POST',
+      body: {
+        emails: firstEmails,
+        config: { senderName: 'Trainer', subject: 'Certificate', message: 'Hello' },
+        sessionId: 'email-session-recipient-cap',
+        deferProcessing: true,
+      },
+    });
+    await handler(first.req, first.res);
+    expect(first.res.statusCode).toBe(200);
+
+    const overflow = httpMocks.createMocks({
+      method: 'POST',
+      body: {
+        emails: [{
+          to: 'overflow@example.com',
+          certificateUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+        }],
+        config: { senderName: 'Trainer', subject: 'Certificate', message: 'Hello' },
+        sessionId: 'email-session-recipient-cap',
+        deferProcessing: true,
+      },
+    });
+    await handler(overflow.req, overflow.res);
+
+    expect(overflow.res.statusCode).toBe(413);
+    expect(addToQueue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/api/send-bulk-email.test.ts
+++ b/__tests__/api/send-bulk-email.test.ts
@@ -35,12 +35,20 @@ jest.mock('@/pages/api/auth/[...nextauth]', () => ({
 jest.mock('@/lib/auth/requireAuth', () => ({
   requireAuth: jest.fn(async () => ({ user: { id: 'u1' } }))
 }));
+jest.mock('@/lib/server/tiers', () => ({
+  checkEmailUsageAvailability: jest.fn(async () => ({ allowed: true, limit: 100, current: 0 })),
+  reserveEmailUsage: jest.fn(async (_userId: string, count: number) => ({
+    allowed: true, limit: 100, current: count
+  }))
+}));
 import handler, { cleanupExpiredEmailQueues } from '../../pages/api/send-bulk-email';
 import { getEmailProvider } from '@/lib/email/provider-factory';
 import { requireAuth } from '@/lib/auth/requireAuth';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
 
 const mockGetEmailProvider = getEmailProvider as jest.MockedFunction<typeof getEmailProvider>;
 const mockedRequireAuth = requireAuth as jest.MockedFunction<typeof requireAuth>;
+const certificateUrl = createSignedGeneratedFileUrl('u_u1/test/certificate.pdf');
 
 describe('/api/send-bulk-email', () => {
   beforeEach(() => {
@@ -64,7 +72,8 @@ describe('/api/send-bulk-email', () => {
             subject: 'Test Subject',
             html: '<p>Test HTML</p>',
             text: 'Test text',
-            attachments: []
+            attachments: [],
+            certificateUrl
           }
         ],
         config: {
@@ -89,7 +98,7 @@ describe('/api/send-bulk-email', () => {
     const first = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'first@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'first@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'deferred-batches',
         deferProcessing: true
@@ -104,7 +113,7 @@ describe('/api/send-bulk-email', () => {
     const final = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'second@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'second@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'deferred-batches',
         deferProcessing: true
@@ -130,7 +139,7 @@ describe('/api/send-bulk-email', () => {
     const first = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'first@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'first@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'session-email-cap',
         deferProcessing: true
@@ -146,8 +155,8 @@ describe('/api/send-bulk-email', () => {
       method: 'POST',
       body: {
         emails: [
-          { to: 'second@example.com', subject: 'Test', html: 'Test' },
-          { to: 'third@example.com', subject: 'Test', html: 'Test' }
+          { to: 'second@example.com', subject: 'Test', html: 'Test', certificateUrl },
+          { to: 'third@example.com', subject: 'Test', html: 'Test', certificateUrl }
         ],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'session-email-cap',
@@ -181,7 +190,7 @@ describe('/api/send-bulk-email', () => {
     const post = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'done@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'done@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'completed-session',
         deferProcessing: true
@@ -243,7 +252,8 @@ describe('/api/send-bulk-email', () => {
         emails: [{
           to: 'first@example.com, invalid, second@example.com',
           subject: 'Test',
-          html: 'Test'
+          html: 'Test',
+          certificateUrl
         }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'mixed-recipient-session',
@@ -266,7 +276,7 @@ describe('/api/send-bulk-email', () => {
     const post = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'stale@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'stale@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'stale-processing-session',
         deferProcessing: true
@@ -293,7 +303,7 @@ describe('/api/send-bulk-email', () => {
     const post = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'paused@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'paused@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'paused-session',
         deferProcessing: true
@@ -355,7 +365,7 @@ describe('/api/send-bulk-email', () => {
     const post = createMocks({
       method: 'POST',
       body: {
-        emails: [{ to: 'owner@example.com', subject: 'Test', html: 'Test' }],
+        emails: [{ to: 'owner@example.com', subject: 'Test', html: 'Test', certificateUrl }],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },
         sessionId: 'shared-session',
         deferProcessing: true
@@ -399,7 +409,8 @@ describe('/api/send-bulk-email', () => {
             senderName: 'Test',
             subject: 'Test',
             html: 'Test',
-            text: 'Test'
+            text: 'Test',
+            certificateUrl
           }
         ],
         config: { senderName: 'Test', subject: 'Test', message: 'Test' },

--- a/__tests__/api/send-email-rate-limit.test.ts
+++ b/__tests__/api/send-email-rate-limit.test.ts
@@ -20,12 +20,22 @@ jest.mock('@/lib/email/provider-factory', () => ({
     sendEmail: async () => ({ success: true, id: 'id123', provider: 'resend' })
   })
 }));
+jest.mock('@/lib/server/tiers', () => ({
+  checkEmailUsageAvailability: jest.fn(async () => ({ allowed: true, limit: 100, current: 0 })),
+  reserveEmailUsage: jest.fn(async () => ({ allowed: true, limit: 100, current: 1 }))
+}));
+jest.mock('@/lib/storage/mark-generated', () => ({
+  markGeneratedFileAsEmailed: jest.fn(async () => undefined)
+}));
+
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
 
 describe('send-email API rate limiting', () => {
   it('returns 429 after exceeding email limit', async () => {
     jest.resetModules();
     process.env.RATE_LIMIT_WINDOW_SECONDS = '1';
     process.env.RATE_LIMIT_EMAIL_PER_MIN = '2';
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
 
     const { default: handler } = await import('@/pages/api/send-email');
 
@@ -38,7 +48,7 @@ describe('send-email API rate limiting', () => {
         senderName: 'T',
         customMessage: 'm',
         deliveryMethod: 'download',
-        downloadUrl: 'https://example.com/cert.pdf'
+        downloadUrl: createSignedGeneratedFileUrl('u_u1/cert.pdf')
       }
     });
 
@@ -55,6 +65,6 @@ describe('send-email API rate limiting', () => {
     ({ req, res } = makeReqRes());
     await handler(req, res);
     expect(res._getStatusCode()).toBe(429);
+    delete process.env.FILE_URL_SIGNING_SECRET;
   });
 });
-

--- a/__tests__/api/send-email-security.test.ts
+++ b/__tests__/api/send-email-security.test.ts
@@ -1,0 +1,123 @@
+/** @jest-environment node */
+
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({ __esModule: true, authOptions: {} }));
+jest.mock('@/lib/server/middleware/featureGate', () => ({
+  withFeatureGate: (_options: unknown, handler: any) => async (req: any, res: any) => {
+    req.user = { id: 'u1', email: 'owner@example.com', tier: 'plus' };
+    return handler(req, res);
+  },
+}));
+jest.mock('@/lib/server/tiers', () => ({
+  checkEmailUsageAvailability: jest.fn(async () => ({ allowed: true, limit: 100, current: 0 })),
+  reserveEmailUsage: jest.fn(async () => ({ allowed: true, limit: 100, current: 2 })),
+}));
+jest.mock('@/lib/email/provider-factory', () => ({
+  getEmailProvider: jest.fn(),
+}));
+jest.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: jest.fn(() => ({ allowed: true })),
+}));
+jest.mock('@/lib/storage/mark-generated', () => ({
+  markGeneratedFileAsEmailed: jest.fn(async () => undefined),
+}));
+
+import httpMocks from 'node-mocks-http';
+import handler from '@/pages/api/send-email';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+import { reserveEmailUsage } from '@/lib/server/tiers';
+import { getEmailProvider } from '@/lib/email/provider-factory';
+
+const mockSendEmail = jest.fn(async () => ({ success: true, id: 'email-1', provider: 'resend' }));
+const mockReserveEmailUsage = reserveEmailUsage as jest.MockedFunction<typeof reserveEmailUsage>;
+const mockGetEmailProvider = getEmailProvider as jest.MockedFunction<typeof getEmailProvider>;
+
+describe('single email abuse controls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEmailProvider.mockReturnValue({ sendEmail: mockSendEmail } as any);
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+  });
+  afterEach(() => delete process.env.FILE_URL_SIGNING_SECRET);
+
+  it('reserves quota for every deduplicated recipient', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        to: 'one@example.com,two@example.com,ONE@example.com',
+        subject: 'Certificate',
+        senderName: 'Trainer',
+        customMessage: 'Hello',
+        deliveryMethod: 'download',
+        downloadUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockReserveEmailUsage).toHaveBeenCalledWith('u1', 2);
+    expect(mockSendEmail.mock.calls[0][0].to).toEqual(['one@example.com', 'two@example.com']);
+  });
+
+  it('rejects arbitrary link delivery before reserving quota or sending', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        to: 'victim@example.com',
+        subject: 'Click here',
+        customMessage: 'Hello',
+        deliveryMethod: 'download',
+        downloadUrl: 'https://evil.example/phish',
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mockReserveEmailUsage).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('rejects display names that could be parsed as an address list', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        to: 'victim@example.com',
+        subject: 'Certificate',
+        senderName: 'attacker@example.com,',
+        customMessage: 'Hello',
+        deliveryMethod: 'download',
+        downloadUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockReserveEmailUsage).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('rejects attachment delivery without a built certificate', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        to: 'victim@example.com',
+        subject: 'Certificate',
+        senderName: 'Trainer',
+        customMessage: 'Hello',
+        deliveryMethod: 'attachment',
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockReserveEmailUsage).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/send-test-email-security.test.ts
+++ b/__tests__/api/send-test-email-security.test.ts
@@ -1,0 +1,99 @@
+/** @jest-environment node */
+
+jest.mock('@/lib/auth/requireAuth', () => ({
+  requireAuth: jest.fn(async () => ({ user: { id: 'u1', email: 'owner@example.com' } })),
+}));
+jest.mock('@/lib/email/provider-factory', () => ({
+  getEmailProvider: jest.fn(),
+}));
+jest.mock('@/lib/server/tiers', () => ({
+  checkEmailUsageAvailability: jest.fn(async () => ({ allowed: true, limit: 100, current: 0 })),
+  reserveEmailUsage: jest.fn(async () => ({ allowed: true, limit: 100, current: 1 })),
+}));
+jest.mock('@/lib/rate-limit', () => ({
+  enforceRateLimit: jest.fn(() => ({ allowed: true })),
+}));
+
+import httpMocks from 'node-mocks-http';
+import handler from '@/pages/api/send-test-email';
+import { createSignedGeneratedFileUrl } from '@/lib/security/signed-generated-url';
+import { reserveEmailUsage } from '@/lib/server/tiers';
+import { getEmailProvider } from '@/lib/email/provider-factory';
+
+const mockSendEmail = jest.fn(async () => ({ success: true, id: 'email-1', provider: 'resend' }));
+const mockReserveEmailUsage = reserveEmailUsage as jest.MockedFunction<typeof reserveEmailUsage>;
+const mockGetEmailProvider = getEmailProvider as jest.MockedFunction<typeof getEmailProvider>;
+
+describe('test email abuse controls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEmailProvider.mockReturnValue({ sendEmail: mockSendEmail } as any);
+    process.env.FILE_URL_SIGNING_SECRET = 'test-file-signing-secret';
+  });
+
+  afterEach(() => delete process.env.FILE_URL_SIGNING_SECRET);
+
+  it('only permits the authenticated account email', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        testEmailAddress: 'victim@example.com',
+        subject: 'Certificate',
+        customMessage: 'Hello',
+        deliveryMethod: 'download',
+        certificateUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(mockReserveEmailUsage).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it('builds safe server-side content and reserves one recipient', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        testEmailAddress: 'OWNER@example.com',
+        senderName: 'Trainer',
+        subject: 'Certificate',
+        customMessage: '<img src=x onerror=alert(1)>',
+        deliveryMethod: 'download',
+        certificateUrl: createSignedGeneratedFileUrl('u_u1/certificate.pdf'),
+        html: '<a href="https://evil.example">phish</a>',
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(mockReserveEmailUsage).toHaveBeenCalledWith('u1', 1);
+    const params = mockSendEmail.mock.calls[0][0];
+    expect(params.html).toContain('&lt;img');
+    expect(params.html).not.toContain('evil.example');
+  });
+
+  it('rejects requested attachment delivery when no PDF is built', async () => {
+    const req = httpMocks.createRequest({
+      method: 'POST',
+      body: {
+        testEmailAddress: 'owner@example.com',
+        senderName: 'Trainer',
+        subject: 'Certificate',
+        customMessage: 'Hello',
+        attachmentData: {},
+      },
+    });
+    const res = httpMocks.createResponse();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mockReserveEmailUsage).not.toHaveBeenCalled();
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/email-quota.test.ts
+++ b/__tests__/lib/email-quota.test.ts
@@ -1,0 +1,83 @@
+jest.mock('@/lib/server/prisma', () => ({
+  __esModule: true,
+  prisma: {
+    user: {
+      updateMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+  default: {
+    user: {
+      updateMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+import { prisma } from '@/lib/server/prisma';
+import { checkEmailUsageAvailability, reserveEmailUsage } from '@/lib/server/tiers';
+
+const user = prisma.user as unknown as {
+  updateMany: jest.Mock;
+  findUnique: jest.Mock;
+};
+
+describe('atomic email quota reservation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reserves the actual recipient count with an atomic limit predicate', async () => {
+    user.updateMany
+      .mockResolvedValueOnce({ count: 0 }) // no daily reset needed
+      .mockResolvedValueOnce({ count: 1 });
+    user.findUnique.mockResolvedValue({ tier: 'plus', dailyEmailCount: 95 });
+
+    const result = await reserveEmailUsage('u1', 5);
+
+    expect(result).toMatchObject({ allowed: true, limit: 100, current: 100 });
+    expect(user.updateMany).toHaveBeenLastCalledWith({
+      where: { id: 'u1', dailyEmailCount: { lte: 95 } },
+      data: {
+        dailyEmailCount: { increment: 5 },
+        lifetimeEmailCount: { increment: 5 },
+      },
+    });
+  });
+
+  it('denies a reservation when another request consumed the remaining quota', async () => {
+    user.updateMany
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 0 });
+    user.findUnique
+      .mockResolvedValueOnce({ tier: 'plus', dailyEmailCount: 99 })
+      .mockResolvedValueOnce({ dailyEmailCount: 100 });
+
+    await expect(reserveEmailUsage('u1', 1)).resolves.toMatchObject({
+      allowed: false,
+      limit: 100,
+      current: 100,
+    });
+  });
+
+  it('cannot reserve email quota for the free tier', async () => {
+    user.updateMany.mockResolvedValueOnce({ count: 0 });
+    user.findUnique.mockResolvedValue({ tier: 'free', dailyEmailCount: 0 });
+
+    await expect(reserveEmailUsage('u1', 1)).resolves.toMatchObject({
+      allowed: false,
+      limit: 0,
+    });
+    expect(user.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('preflights capacity without incrementing usage', async () => {
+    user.updateMany.mockResolvedValueOnce({ count: 0 });
+    user.findUnique.mockResolvedValue({ tier: 'plus', dailyEmailCount: 99 });
+
+    await expect(checkEmailUsageAvailability('u1', 2)).resolves.toMatchObject({
+      allowed: false,
+      limit: 100,
+      current: 99,
+    });
+    expect(user.updateMany).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/signed-generated-url.test.ts
+++ b/__tests__/lib/signed-generated-url.test.ts
@@ -2,6 +2,7 @@ import {
   createSignedGeneratedFileUrl,
   normalizeGeneratedPdfPath,
   SignedFileUrlError,
+  verifySignedGeneratedFileCapabilityUrl,
   verifySignedGeneratedFileUrl,
 } from '@/lib/security/signed-generated-url';
 
@@ -34,6 +35,30 @@ describe('signed generated file URLs', () => {
       url.searchParams.get('signature')!,
       1_030_000,
     )).toBe('individual_1/Alice Smith.pdf');
+  });
+
+  it('binds absolute capability URLs to the configured application origin and owner', () => {
+    process.env.NEXTAUTH_URL = 'https://certificates.example';
+    const url = createSignedGeneratedFileUrl('u_user/session/certificate.pdf');
+    expect(verifySignedGeneratedFileCapabilityUrl(url, 'user'))
+      .toBe('u_user/session/certificate.pdf');
+    expect(() => verifySignedGeneratedFileCapabilityUrl(
+      url.replace('https://certificates.example', 'https://evil.example'),
+      'user',
+    )).toThrow(SignedFileUrlError);
+    expect(() => verifySignedGeneratedFileCapabilityUrl(url, 'other'))
+      .toThrow(SignedFileUrlError);
+    const relativeUrl = new URL(url).pathname + new URL(url).search;
+    expect(() => verifySignedGeneratedFileCapabilityUrl(`//evil.example${relativeUrl}`, 'user'))
+      .toThrow(SignedFileUrlError);
+    expect(() => verifySignedGeneratedFileCapabilityUrl(` ${relativeUrl}`, 'user'))
+      .toThrow(SignedFileUrlError);
+    expect(() => verifySignedGeneratedFileCapabilityUrl('\\\\evil.example\\api\\files\\download', 'user'))
+      .toThrow(SignedFileUrlError);
+    expect(() => verifySignedGeneratedFileCapabilityUrl(`/\\evil.example${relativeUrl}`, 'user'))
+      .toThrow(SignedFileUrlError);
+    expect(() => verifySignedGeneratedFileCapabilityUrl(`/\\/evil.example${relativeUrl}`, 'user'))
+      .toThrow(SignedFileUrlError);
   });
 
   it('rejects tampering, expiry, traversal, and non-PDF paths', () => {

--- a/components/modals/BulkEmailModal.tsx
+++ b/components/modals/BulkEmailModal.tsx
@@ -383,13 +383,11 @@ export function BulkEmailModal({
           testEmailAddress: testEmail.trim(),
           senderName: emailConfig.senderName,
           subject: emailConfig.subject,
-          html: useAttachmentDelivery
-            ? buildAttachmentEmail(emailConfig.message)
-            : buildLinkEmail(emailConfig.message, firstCert.downloadUrl),
-          text: emailConfig.message,
+          customMessage: emailConfig.message,
+          deliveryMethod: useAttachmentDelivery ? 'attachment' : 'download',
+          certificateUrl: firstCert.downloadUrl,
           attachment,
-          attachmentData,
-          certificateUrl: firstCert.downloadUrl
+          attachmentData
         })
       });
 

--- a/lib/auth/requireAuth.ts
+++ b/lib/auth/requireAuth.ts
@@ -24,7 +24,13 @@ export async function requireAuth(req: NextApiRequest, res: NextApiResponse) {
   if (token) {
     const uid = (token as any).uid ?? token.sub;
     if (uid) touchUser(String(uid));
-    return { user: { id: uid } } as any;
+    return {
+      user: {
+        id: uid,
+        email: typeof token.email === 'string' ? token.email : null,
+        name: typeof token.name === 'string' ? token.name : null,
+      },
+    } as any;
   }
 
   // Fallback: server session (may be undefined in tests without NextAuth wiring)

--- a/lib/email-templates.ts
+++ b/lib/email-templates.ts
@@ -2,12 +2,24 @@
  * Email template builders for certificate delivery
  */
 
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, character => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[character] as string);
+}
+
 export function buildLinkEmail(message: string, downloadUrl: string): string {
+  const safeMessage = escapeHtml(message);
+  const safeDownloadUrl = escapeHtml(downloadUrl);
   return `
     <div style="font-family: Arial, sans-serif;">
-      <div style="white-space: pre-wrap;">${message}</div>
+      <div style="white-space: pre-wrap;">${safeMessage}</div>
       <p style="margin: 30px 0;">
-        <a href="${downloadUrl}" 
+        <a href="${safeDownloadUrl}"
            style="background-color: #2D6A4F; color: white; padding: 12px 24px; 
                   text-decoration: none; border-radius: 5px; display: inline-block;">
           Download Certificate
@@ -21,9 +33,10 @@ export function buildLinkEmail(message: string, downloadUrl: string): string {
 }
 
 export function buildAttachmentEmail(message: string): string {
+  const safeMessage = escapeHtml(message);
   return `
     <div style="font-family: Arial, sans-serif;">
-      <div style="white-space: pre-wrap;">${message}</div>
+      <div style="white-space: pre-wrap;">${safeMessage}</div>
       <p style="color: #666; font-size: 14px; margin-top: 20px;">
         Your certificate is attached to this email.
       </p>

--- a/lib/email/abuse-controls.ts
+++ b/lib/email/abuse-controls.ts
@@ -1,0 +1,42 @@
+export const MAX_RECIPIENTS_PER_MESSAGE = 10;
+export const MAX_BULK_RECIPIENTS = 500;
+export const MAX_EMAIL_SUBJECT_LENGTH = 200;
+export const MAX_EMAIL_SENDER_NAME_LENGTH = 100;
+export const MAX_EMAIL_MESSAGE_LENGTH = 10_000;
+
+export class EmailRequestError extends Error {
+  constructor(message: string, public readonly statusCode: number = 400) {
+    super(message);
+    this.name = 'EmailRequestError';
+  }
+}
+
+export function requireBoundedEmailText(
+  value: unknown,
+  field: string,
+  maxLength: number,
+): string {
+  if (typeof value !== 'string') throw new EmailRequestError(`${field} is required`);
+  const trimmed = value.trim();
+  if (!trimmed) throw new EmailRequestError(`${field} is required`);
+  if (trimmed.length > maxLength) {
+    throw new EmailRequestError(`${field} is too long`, 413);
+  }
+  return trimmed;
+}
+
+export function assertRecipientCount(count: number, maximum: number): void {
+  if (count > maximum) {
+    throw new EmailRequestError(`Too many email recipients; maximum is ${maximum}`, 413);
+  }
+}
+
+export function requireSafeEmailHeader(value: string, field: string): string {
+  // The provider receives `senderName <address>` as a mailbox header. Reject
+  // RFC 5322 address-list and quoted-string delimiters so the display name
+  // cannot be reinterpreted as another mailbox or header structure.
+  if (/[\r\n\0]/.test(value) || (field === 'senderName' && /[<>,;:@"\\]/.test(value))) {
+    throw new EmailRequestError(`${field} contains invalid characters`);
+  }
+  return value;
+}

--- a/lib/security/signed-generated-url.ts
+++ b/lib/security/signed-generated-url.ts
@@ -109,3 +109,52 @@ export function verifySignedGeneratedFileUrl(
   }
   return normalizedPath;
 }
+
+export function verifySignedGeneratedFileCapabilityUrl(
+  fileUrl: string,
+  userId: string,
+  nowMs: number = Date.now(),
+): string {
+  if (typeof fileUrl !== 'string' || fileUrl !== fileUrl.trim() || fileUrl.includes('\\')) {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+  const isRelativeUrl = fileUrl.startsWith('/') && !fileUrl.startsWith('//');
+  const isAbsoluteHttpUrl = /^https?:\/\//i.test(fileUrl);
+  if (!isRelativeUrl && !isAbsoluteHttpUrl) {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(fileUrl, 'http://local.invalid');
+  } catch {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+  if (isAbsoluteHttpUrl) {
+    const configuredOrigin = process.env.NEXTAUTH_URL;
+    let appOrigin: string;
+    try {
+      appOrigin = configuredOrigin ? new URL(configuredOrigin).origin : '';
+    } catch {
+      appOrigin = '';
+    }
+    if (!appOrigin || parsed.origin !== appOrigin) {
+      throw new SignedFileUrlError('Generated file URL has an invalid origin', 403);
+    }
+  } else if (parsed.origin !== 'http://local.invalid') {
+    throw new SignedFileUrlError('Generated file URL has an invalid origin', 403);
+  }
+  if (parsed.pathname !== '/api/files/download') {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+  const signedPath = parsed.searchParams.get('path');
+  const expires = parsed.searchParams.get('expires');
+  const signature = parsed.searchParams.get('signature');
+  if (!signedPath || !expires || !signature) {
+    throw new SignedFileUrlError('Invalid generated file URL', 400);
+  }
+  const verifiedPath = verifySignedGeneratedFileUrl(signedPath, expires, signature, nowMs);
+  if (!verifiedPath.startsWith(`u_${userId}/`)) {
+    throw new SignedFileUrlError('Generated file does not belong to the current user', 403);
+  }
+  return verifiedPath;
+}

--- a/lib/server/tiers.ts
+++ b/lib/server/tiers.ts
@@ -1,6 +1,6 @@
 // Server-side tier detection and management
 import { prisma } from './prisma';
-import type { UserTier } from '@/types/user';
+import { getTierLimits, type UserTier } from '@/types/user';
 import { isValidEmail, normaliseEmail } from '@/utils/email-utils';
 
 // Get admin configuration from environment variables
@@ -145,31 +145,103 @@ export async function updateUserTierIfNeeded(userId: string): Promise<DbUser> {
  * Check if usage counters need to be reset (daily reset)
  */
 export async function resetDailyUsageIfNeeded(userId: string): Promise<void> {
+  const now = new Date();
+  const utcDayStart = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  ));
+  await prisma.user.updateMany({
+    where: { id: userId, lastUsageReset: { lt: utcDayStart } },
+    data: {
+      dailyPdfCount: 0,
+      dailyEmailCount: 0,
+      lastUsageReset: now,
+    },
+  });
+}
+
+export interface EmailQuotaReservation {
+  allowed: boolean;
+  limit: number | null;
+  current: number;
+  tier?: UserTier;
+}
+
+export async function checkEmailUsageAvailability(
+  userId: string,
+  recipientCount: number,
+): Promise<EmailQuotaReservation> {
+  if (!Number.isSafeInteger(recipientCount) || recipientCount <= 0) {
+    throw new Error('Recipient count must be a positive integer');
+  }
+  await resetDailyUsageIfNeeded(userId);
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: { lastUsageReset: true }
+    select: { tier: true, dailyEmailCount: true },
   });
-  
-  if (!user) return;
-  
-  const now = new Date();
-  const lastReset = new Date(user.lastUsageReset);
-  
-  // Check if it's a new day (UTC)
-  const isNewDay = now.getUTCDate() !== lastReset.getUTCDate() ||
-                   now.getUTCMonth() !== lastReset.getUTCMonth() ||
-                   now.getUTCFullYear() !== lastReset.getUTCFullYear();
-  
-  if (isNewDay) {
-    await prisma.user.update({
-      where: { id: userId },
-      data: {
-        dailyPdfCount: 0,
-        dailyEmailCount: 0,
-        lastUsageReset: now
-      }
-    });
+  if (!user) return { allowed: false, limit: 0, current: 0 };
+  const tier = user.tier as UserTier;
+  const limit = getTierLimits(tier).dailyEmailLimit;
+  return {
+    allowed: limit === null || user.dailyEmailCount + recipientCount <= limit,
+    limit,
+    current: user.dailyEmailCount,
+    tier,
+  };
+}
+
+/** Atomically reserve quota for the number of actual recipients being sent. */
+export async function reserveEmailUsage(
+  userId: string,
+  recipientCount: number,
+): Promise<EmailQuotaReservation> {
+  if (!Number.isSafeInteger(recipientCount) || recipientCount <= 0) {
+    throw new Error('Recipient count must be a positive integer');
   }
+  await resetDailyUsageIfNeeded(userId);
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { tier: true, dailyEmailCount: true },
+  });
+  if (!user) return { allowed: false, limit: 0, current: 0 };
+
+  const tier = user.tier as UserTier;
+  const limit = getTierLimits(tier).dailyEmailLimit;
+  if (limit !== null && recipientCount > limit) {
+    return { allowed: false, limit, current: user.dailyEmailCount, tier };
+  }
+
+  const reservation = await prisma.user.updateMany({
+    where: {
+      id: userId,
+      ...(limit === null
+        ? {}
+        : { dailyEmailCount: { lte: limit - recipientCount } }),
+    },
+    data: {
+      dailyEmailCount: { increment: recipientCount },
+      lifetimeEmailCount: { increment: recipientCount },
+    },
+  });
+  if (reservation.count === 0) {
+    const current = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { dailyEmailCount: true },
+    });
+    return {
+      allowed: false,
+      limit,
+      current: current?.dailyEmailCount ?? user.dailyEmailCount,
+      tier,
+    };
+  }
+  return {
+    allowed: true,
+    limit,
+    current: user.dailyEmailCount + recipientCount,
+    tier,
+  };
 }
 
 /**

--- a/lib/storage/mark-generated.ts
+++ b/lib/storage/mark-generated.ts
@@ -5,33 +5,13 @@ import { isS3Configured, markAsEmailedS3 } from '@/lib/s3-client';
 import { getGeneratedDir, resolvePathWithin } from '@/lib/paths';
 import {
   SignedFileUrlError,
-  verifySignedGeneratedFileUrl,
+  verifySignedGeneratedFileCapabilityUrl,
 } from '@/lib/security/signed-generated-url';
 
 export async function markGeneratedFileAsEmailed(fileUrl: string, userId: string): Promise<void> {
   const provider = process.env.STORAGE_PROVIDER || 'local';
 
-  let parsed: URL;
-  try {
-    parsed = new URL(fileUrl, 'http://local.invalid');
-  } catch {
-    throw new SignedFileUrlError('Invalid generated file URL', 400);
-  }
-  if (parsed.pathname !== '/api/files/download') {
-    throw new SignedFileUrlError('Invalid generated file URL', 400);
-  }
-
-  const signedPath = parsed.searchParams.get('path');
-  const expires = parsed.searchParams.get('expires');
-  const signature = parsed.searchParams.get('signature');
-  if (!signedPath || !expires || !signature) {
-    throw new SignedFileUrlError('Invalid generated file URL', 400);
-  }
-
-  const verifiedPath = verifySignedGeneratedFileUrl(signedPath, expires, signature);
-  if (!verifiedPath.startsWith(`u_${userId}/`)) {
-    throw new SignedFileUrlError('Generated file does not belong to the current user', 403);
-  }
+  const verifiedPath = verifySignedGeneratedFileCapabilityUrl(fileUrl, userId);
   const key = `generated/${verifiedPath}`;
 
   if (provider === 'local') {

--- a/pages/api/send-bulk-email.ts
+++ b/pages/api/send-bulk-email.ts
@@ -7,6 +7,23 @@ import { enforceRateLimit } from '@/lib/rate-limit';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
 import { getMaxPdfSourceBytes, PdfSourceError } from '@/lib/security/trusted-pdf-source';
 import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
+import { buildAttachmentEmail, buildLinkEmail } from '@/lib/email-templates';
+import { checkEmailUsageAvailability, reserveEmailUsage } from '@/lib/server/tiers';
+import {
+  assertRecipientCount,
+  EmailRequestError,
+  MAX_BULK_RECIPIENTS,
+  MAX_EMAIL_MESSAGE_LENGTH,
+  MAX_EMAIL_SENDER_NAME_LENGTH,
+  MAX_EMAIL_SUBJECT_LENGTH,
+  MAX_RECIPIENTS_PER_MESSAGE,
+  requireBoundedEmailText,
+  requireSafeEmailHeader,
+} from '@/lib/email/abuse-controls';
+import {
+  SignedFileUrlError,
+  verifySignedGeneratedFileCapabilityUrl,
+} from '@/lib/security/signed-generated-url';
 
 const MAX_BULK_EMAILS = 500;
 const BULK_ATTACHMENT_CONCURRENCY = 4;
@@ -49,6 +66,7 @@ export const config = {
 // Store queue managers in memory (in production, use Redis or database)
 const queueManagers = new Map<string, EmailQueueManager>();
 const queueAttachmentBytes = new Map<string, number>();
+const queueRecipientCounts = new Map<string, number>();
 const queueIngestionLocks = new Map<string, Promise<void>>();
 type QueueStatus = ReturnType<EmailQueueManager['getStatus']>;
 const terminalQueueStatuses = new Map<
@@ -162,6 +180,27 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
       res.status(400).json({ error: 'Email configuration incomplete' });
       return;
     }
+    const safeSenderName = requireSafeEmailHeader(
+      requireBoundedEmailText(
+        config.senderName,
+        'senderName',
+        MAX_EMAIL_SENDER_NAME_LENGTH,
+      ),
+      'senderName',
+    );
+    const safeSubject = requireSafeEmailHeader(
+      requireBoundedEmailText(
+        config.subject,
+        'subject',
+        MAX_EMAIL_SUBJECT_LENGTH,
+      ),
+      'subject',
+    );
+    const safeMessage = requireBoundedEmailText(
+      config.message,
+      'message',
+      MAX_EMAIL_MESSAGE_LENGTH,
+    );
 
     // Rate limit after validation
     const userId = (req as any).__uid as string | undefined;
@@ -184,13 +223,13 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     let successPayload: Record<string, unknown> | null = null;
     await withQueueIngestionLock(key, async () => {
       terminalQueueStatuses.delete(key);
-      // Get or create queue manager for this session
+      // Resolve the provider early, but do not retain an empty queue if later
+      // validation or attachment construction fails.
       let queueManager = queueManagers.get(key);
+      let provider: ReturnType<typeof getEmailProvider> | undefined;
       if (!queueManager) {
         try {
-          const provider = getEmailProvider();
-          queueManager = new EmailQueueManager(provider);
-          queueManagers.set(key, queueManager);
+          provider = getEmailProvider();
         } catch {
           res.status(500).json({
             error: 'No email provider configured. Please set up Resend or AWS SES.'
@@ -205,10 +244,6 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
       // Parse recipients and filter out emails with no valid addresses
       type EmailInput = {
         to: string;
-        senderName?: string;
-        subject: string;
-        html: string;
-        text?: string;
         attachmentData?: { data: number[] | string; filename: string };
         attachments?: {
           path?: string;
@@ -221,6 +256,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
       const emailsWithRecipients = (emails as EmailInput[])
         .map((email) => {
           const { valid, rejected } = parseRecipientsDetailed(email.to || '');
+          assertRecipientCount(valid.length, MAX_RECIPIENTS_PER_MESSAGE);
           rejectedEmails.push(...rejected);
           return { ...email, recipients: valid };
         })
@@ -238,9 +274,20 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
         });
         return;
       }
+      const recipientCount = emailsWithRecipients.reduce(
+        (total, email) => total + email.recipients.length,
+        0,
+      );
+      assertRecipientCount(recipientCount, MAX_BULK_RECIPIENTS);
+      if ((queueRecipientCounts.get(key) || 0) + recipientCount > MAX_BULK_RECIPIENTS) {
+        throw new EmailRequestError(
+          `A bulk email session can contain at most ${MAX_BULK_RECIPIENTS} recipients`,
+          413,
+        );
+      }
 
       if (
-        queueManager.getQueueLength() + emailsWithRecipients.length >
+        (queueManager?.getQueueLength() || 0) + emailsWithRecipients.length >
         MAX_BULK_EMAILS
       ) {
         throw new PdfSourceError(
@@ -248,6 +295,17 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
           `A bulk email session can contain at most ${MAX_BULK_EMAILS} emails`,
           413
         );
+      }
+
+      const quotaAvailability = await checkEmailUsageAvailability(userId, recipientCount);
+      if (!quotaAvailability.allowed) {
+        res.status(403).json({
+          error: 'email limit reached',
+          code: 'LIMIT_REACHED',
+          limit: quotaAvailability.limit,
+          current: quotaAvailability.current,
+        });
+        return;
       }
 
       // Build attachments with bounded concurrency and a request-wide byte
@@ -277,20 +335,35 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
 
         const builtBatch = await Promise.all(
           batch.map(async (email) => {
+            const requestedAttachment = email.attachmentData !== undefined
+              || Boolean(email.attachments?.some(attachment =>
+                Boolean(attachment?.path || attachment?.content)
+              ));
             const attachments = await buildPdfAttachments({
               attachmentData: email.attachmentData,
               attachments: email.attachments,
               maxTotalBytes: perEmailBudget
-            });
+            }) || [];
+            if (requestedAttachment && attachments.length === 0) {
+              throw new EmailRequestError('Invalid PDF attachment data');
+            }
+            if (attachments.length === 0) {
+              if (typeof email.certificateUrl !== 'string') {
+                throw new EmailRequestError('A certificate download URL is required');
+              }
+              verifySignedGeneratedFileCapabilityUrl(email.certificateUrl, userId);
+            }
 
             return {
               to: email.recipients,
-              from: email.senderName
-                ? `${email.senderName} <${fromAddress}>`
-                : `Bamboobot Certificates <${fromAddress}>`,
-              subject: email.subject,
-              html: email.html,
-              text: email.text,
+              from: `${safeSenderName} <${fromAddress}>`,
+              subject: safeSubject,
+              html: attachments.length > 0
+                ? buildAttachmentEmail(safeMessage)
+                : buildLinkEmail(safeMessage, email.certificateUrl as string),
+              text: attachments.length > 0
+                ? safeMessage
+                : `${safeMessage}\n\nDownload your certificate: ${email.certificateUrl}`,
               attachments,
               certificateUrl: email.certificateUrl
             };
@@ -313,8 +386,26 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
         emailParams.push(...builtBatch);
       }
 
+      const quota = await reserveEmailUsage(userId, recipientCount);
+      if (!quota.allowed) {
+        res.status(403).json({
+          error: 'email limit reached',
+          code: 'LIMIT_REACHED',
+          limit: quota.limit,
+          current: quota.current,
+        });
+        return;
+      }
+
+      const isNewQueue = !queueManager;
+      if (!queueManager) {
+        queueManager = new EmailQueueManager(provider as ReturnType<typeof getEmailProvider>);
+      }
+
       await queueManager.addToQueue(emailParams);
+      if (isNewQueue) queueManagers.set(key, queueManager);
       queueAttachmentBytes.set(key, totalAttachmentBytes);
+      queueRecipientCounts.set(key, (queueRecipientCounts.get(key) || 0) + recipientCount);
 
       await markGeneratedRetentionInBatches(emailParams
         .map(email => email.certificateUrl)
@@ -339,7 +430,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse): Promise<vo
     res.status(200).json(successPayload);
     return;
   } catch (error) {
-    if (error instanceof PdfSourceError) {
+    if (error instanceof PdfSourceError || error instanceof SignedFileUrlError || error instanceof EmailRequestError) {
       res.status(error.statusCode).json({ error: error.message });
       return;
     }
@@ -388,6 +479,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse): Promise<voi
           await queueManager.clear();
           queueManagers.delete(key);
           queueAttachmentBytes.delete(key);
+          queueRecipientCounts.delete(key);
         }
       });
     }
@@ -464,6 +556,7 @@ async function handlePut(req: NextApiRequest, res: NextApiResponse): Promise<voi
         queueManagers.delete(key);
         queueAttachmentBytes.delete(key);
         terminalQueueStatuses.delete(key);
+        queueRecipientCounts.delete(key);
       } else {
         res.status(400).json({ error: 'Invalid action' });
         return;
@@ -519,6 +612,7 @@ async function enforcePausedAttachmentLimit(): Promise<void> {
         await manager.clear();
         queueManagers.delete(key);
         queueAttachmentBytes.delete(key);
+        queueRecipientCounts.delete(key);
       });
     }
   });
@@ -537,6 +631,7 @@ export async function cleanupExpiredEmailQueues(now = Date.now()): Promise<void>
       await manager.clear();
       queueManagers.delete(key);
       queueAttachmentBytes.delete(key);
+      queueRecipientCounts.delete(key);
     })
   ));
   for (const [key, terminal] of terminalQueueStatuses) {

--- a/pages/api/send-email.ts
+++ b/pages/api/send-email.ts
@@ -2,12 +2,26 @@ import { NextApiResponse } from 'next';
 import type { AuthenticatedRequest } from '@/types/api';
 import { getEmailProvider } from '@/lib/email/provider-factory';
 import { buildLinkEmail, buildAttachmentEmail } from '@/lib/email-templates';
-import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { withFeatureGate } from '@/lib/server/middleware/featureGate';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
 import { PdfSourceError } from '@/lib/security/trusted-pdf-source';
 import { markGeneratedFileAsEmailed } from '@/lib/storage/mark-generated';
+import { checkEmailUsageAvailability, reserveEmailUsage } from '@/lib/server/tiers';
+import {
+  assertRecipientCount,
+  EmailRequestError,
+  MAX_EMAIL_MESSAGE_LENGTH,
+  MAX_EMAIL_SENDER_NAME_LENGTH,
+  MAX_EMAIL_SUBJECT_LENGTH,
+  MAX_RECIPIENTS_PER_MESSAGE,
+  requireBoundedEmailText,
+  requireSafeEmailHeader,
+} from '@/lib/email/abuse-controls';
+import {
+  SignedFileUrlError,
+  verifySignedGeneratedFileCapabilityUrl,
+} from '@/lib/security/signed-generated-url';
 
 export const config = {
   api: {
@@ -65,6 +79,36 @@ async function sendEmailHandler(
       res.status(400).json({ error: 'No valid email addresses provided' });
       return;
     }
+    assertRecipientCount(recipients.length, MAX_RECIPIENTS_PER_MESSAGE);
+    const safeSubject = requireSafeEmailHeader(
+      requireBoundedEmailText(subject, 'subject', MAX_EMAIL_SUBJECT_LENGTH),
+      'subject',
+    );
+    const safeMessage = requireBoundedEmailText(customMessage, 'message', MAX_EMAIL_MESSAGE_LENGTH);
+    const safeSenderName = senderName === undefined || senderName === ''
+      ? 'Bamboobot Certificates'
+      : requireSafeEmailHeader(
+          requireBoundedEmailText(senderName, 'senderName', MAX_EMAIL_SENDER_NAME_LENGTH),
+          'senderName',
+        );
+    if (deliveryMethod !== 'download' && deliveryMethod !== 'attachment') {
+      throw new EmailRequestError('Invalid delivery method');
+    }
+    if (deliveryMethod === 'download') {
+      if (typeof downloadUrl !== 'string') throw new EmailRequestError('A certificate download URL is required');
+      verifySignedGeneratedFileCapabilityUrl(downloadUrl, userId);
+    }
+
+    const quotaAvailability = await checkEmailUsageAvailability(userId, recipients.length);
+    if (!quotaAvailability.allowed) {
+      res.status(403).json({
+        error: 'email limit reached',
+        code: 'LIMIT_REACHED',
+        limit: quotaAvailability.limit,
+        current: quotaAvailability.current,
+      });
+      return;
+    }
 
     // Get email provider (supports both Resend and SES)
     const emailProvider = getEmailProvider();
@@ -73,24 +117,22 @@ async function sendEmailHandler(
     const fromAddress = process.env.EMAIL_FROM || 'noreply@certificates.com';
 
     // Build proper from field with sender name
-    const fromField = senderName 
-      ? `${senderName} <${fromAddress}>`
-      : `Bamboobot Certificates <${fromAddress}>`;
+    const fromField = `${safeSenderName} <${fromAddress}>`;
 
     // Create HTML content using shared templates
     const htmlContent = deliveryMethod === 'download' 
-      ? buildLinkEmail(customMessage, downloadUrl)
-      : buildAttachmentEmail(customMessage);
+      ? buildLinkEmail(safeMessage, downloadUrl)
+      : buildAttachmentEmail(safeMessage);
 
     // Create text content
     const textContent = deliveryMethod === 'download' ? 
-      `${customMessage}
+      `${safeMessage}
 
 You can download your certificate using this secure link: ${downloadUrl}
 
 Important: This download link will expire in 90 days. Please save your certificate to your device.` 
     : 
-      customMessage;
+      safeMessage;
 
     // Build attachments if delivery method is attachment
     const attachments = deliveryMethod === 'attachment'
@@ -100,12 +142,26 @@ Important: This download link will expire in 90 days. Please save your certifica
           defaultFilename: attachmentName || 'certificate.pdf'
         })
       : undefined;
+    if (deliveryMethod === 'attachment' && (!attachments || attachments.length === 0)) {
+      throw new EmailRequestError('A certificate attachment is required');
+    }
+
+    const quota = await reserveEmailUsage(userId, recipients.length);
+    if (!quota.allowed) {
+      res.status(403).json({
+        error: 'email limit reached',
+        code: 'LIMIT_REACHED',
+        limit: quota.limit,
+        current: quota.current,
+      });
+      return;
+    }
 
     // Prepare email parameters using the standard EmailParams interface
     const emailParams = {
       to: recipients,
       from: fromField,
-      subject,
+      subject: safeSubject,
       html: htmlContent,
       text: textContent,
       attachments
@@ -139,7 +195,7 @@ Important: This download link will expire in 90 days. Please save your certifica
     return;
 
   } catch (error) {
-    if (error instanceof PdfSourceError) {
+    if (error instanceof PdfSourceError || error instanceof SignedFileUrlError || error instanceof EmailRequestError) {
       res.status(error.statusCode).json({ error: error.message });
       return;
     }
@@ -157,7 +213,7 @@ Important: This download link will expire in 90 days. Please save your certifica
 export default withFeatureGate(
   { 
     feature: 'email', 
-    increment: true,
+    increment: false,
     metadata: { endpoint: 'send-email' }
   },
   sendEmailHandler

--- a/pages/api/send-test-email.ts
+++ b/pages/api/send-test-email.ts
@@ -5,6 +5,20 @@ import { requireAuth } from '@/lib/auth/requireAuth';
 import { enforceRateLimit } from '@/lib/rate-limit';
 import { parseRecipientsDetailed, buildPdfAttachments } from '@/utils/email-utils';
 import { PdfSourceError } from '@/lib/security/trusted-pdf-source';
+import { buildAttachmentEmail, buildLinkEmail } from '@/lib/email-templates';
+import { checkEmailUsageAvailability, reserveEmailUsage } from '@/lib/server/tiers';
+import {
+  EmailRequestError,
+  MAX_EMAIL_MESSAGE_LENGTH,
+  MAX_EMAIL_SENDER_NAME_LENGTH,
+  MAX_EMAIL_SUBJECT_LENGTH,
+  requireBoundedEmailText,
+  requireSafeEmailHeader,
+} from '@/lib/email/abuse-controls';
+import {
+  SignedFileUrlError,
+  verifySignedGeneratedFileCapabilityUrl,
+} from '@/lib/security/signed-generated-url';
 
 export const config = {
   api: {
@@ -24,7 +38,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // Require auth
   const session = await requireAuth(req, res);
   if (!session) return;
-  const userId = (session.user as any).id as string;
+  const sessionUser = session.user as { id: string; email?: string | null };
+  const userId = sessionUser.id;
 
   // Rate limit test emails
   const rl = enforceRateLimit(req, res, { userId, route: 'send-test-email', category: 'email' });
@@ -34,7 +49,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const { testEmailAddress, senderName, subject, html, text, attachment, attachmentData } = req.body;
+    const {
+      testEmailAddress,
+      senderName,
+      subject,
+      customMessage,
+      deliveryMethod,
+      certificateUrl,
+      attachment,
+      attachmentData,
+    } = req.body;
 
     if (!testEmailAddress || !testEmailAddress.trim()) {
       res.status(400).json({ error: 'Test email address is required' });
@@ -50,9 +74,39 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       res.status(400).json({ error: 'Invalid email address format' });
       return;
     }
+    const accountEmail = sessionUser.email?.trim().toLowerCase();
+    if (!accountEmail || recipients.length !== 1 || recipients[0] !== accountEmail) {
+      res.status(403).json({ error: 'Test emails can only be sent to your account email address' });
+      return;
+    }
 
-    if (!subject || !html) {
-      res.status(400).json({ error: 'Email subject and content are required' });
+    const safeSubject = requireSafeEmailHeader(
+      requireBoundedEmailText(subject, 'subject', MAX_EMAIL_SUBJECT_LENGTH),
+      'subject',
+    );
+    const safeMessage = requireBoundedEmailText(customMessage, 'message', MAX_EMAIL_MESSAGE_LENGTH);
+    const safeSenderName = senderName === undefined || senderName === ''
+      ? 'Bamboobot Certificates'
+      : requireSafeEmailHeader(
+          requireBoundedEmailText(senderName, 'senderName', MAX_EMAIL_SENDER_NAME_LENGTH),
+          'senderName',
+        );
+    const hasAttachment = Boolean(attachmentData || attachment);
+    if (!hasAttachment) {
+      if (deliveryMethod !== 'download' || typeof certificateUrl !== 'string') {
+        throw new EmailRequestError('A certificate download URL is required');
+      }
+      verifySignedGeneratedFileCapabilityUrl(certificateUrl, userId);
+    }
+
+    const quotaAvailability = await checkEmailUsageAvailability(userId, 1);
+    if (!quotaAvailability.allowed) {
+      res.status(403).json({
+        error: 'email limit reached',
+        code: 'LIMIT_REACHED',
+        limit: quotaAvailability.limit,
+        current: quotaAvailability.current,
+      });
       return;
     }
 
@@ -75,16 +129,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       attachmentData,
       attachment
     });
+    if (hasAttachment && (!attachments || attachments.length === 0)) {
+      throw new EmailRequestError('Invalid PDF attachment data');
+    }
+
+    const quota = await reserveEmailUsage(userId, 1);
+    if (!quota.allowed) {
+      res.status(403).json({
+        error: 'email limit reached',
+        code: 'LIMIT_REACHED',
+        limit: quota.limit,
+        current: quota.current,
+      });
+      return;
+    }
 
     // Send the test email
     const emailParams: EmailParams = {
       to: recipients,
-      from: senderName
-        ? `${senderName} <${fromAddress}>`
-        : `Bamboobot Certificates <${fromAddress}>`,
-      subject: `[TEST] ${subject}`,
-      html,
-      text,
+      from: `${safeSenderName} <${fromAddress}>`,
+      subject: `[TEST] ${safeSubject}`,
+      html: hasAttachment
+        ? buildAttachmentEmail(safeMessage)
+        : buildLinkEmail(safeMessage, certificateUrl),
+      text: hasAttachment
+        ? safeMessage
+        : `${safeMessage}\n\nDownload your certificate: ${certificateUrl}`,
       attachments
     };
 
@@ -101,7 +171,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       provider: result.provider
     });
   } catch (error) {
-    if (error instanceof PdfSourceError) {
+    if (error instanceof PdfSourceError || error instanceof SignedFileUrlError || error instanceof EmailRequestError) {
       res.status(error.statusCode).json({ error: error.message });
       return;
     }


### PR DESCRIPTION
## Summary
- enforce atomic email quotas using actual deduplicated recipient counts across single, bulk, and test sends
- restrict test email to the authenticated account and build escaped server-side content
- require owner-bound signed download capabilities or validated PDF attachments, with recipient/session caps and header hardening

## Verification
- full Jest suite: 69 suites passed, 568 passed, 1 skipped
- focused final security suites: passing
- production build: passing
- lint: passing (existing warnings only)
- Claude adversarial review: CLEAN
- ultra adversarial review: CLEAN
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->