### PR TITLE
security: preserve progressive PDF recipient identity

### DIFF
--- a/__tests__/components/modals/IndividualPdfsModal.performance.test.tsx
+++ b/__tests__/components/modals/IndividualPdfsModal.performance.test.tsx
@@ -77,4 +77,53 @@ describe('IndividualPdfsModal large result lists', () => {
       expect.objectContaining({ filename: 'Ada_Lovelace.pdf' })
     );
   });
+
+  it('keeps a successful progressive PDF paired with its original recipient after an earlier failure', () => {
+    const sendCertificateEmail = jest.fn();
+    render(
+      <IndividualPdfsModal
+        isGeneratingIndividual={false}
+        individualPdfsData={[
+          {
+            filename: 'second.pdf',
+            url: '/generated/second.pdf',
+            originalIndex: 1
+          }
+        ]}
+        tableData={[
+          { Name: 'First Recipient', Email: 'first@example.com' },
+          { Name: 'Second Recipient', Email: 'second@example.com' }
+        ]}
+        selectedNamingColumn="Name"
+        setSelectedNamingColumn={jest.fn()}
+        emailSendingStatus={{ 1: 'sent' }}
+        hasEmailColumn
+        emailConfig={{
+          senderName: 'Certificates',
+          subject: 'Your certificate',
+          message: 'Hello',
+          deliveryMethod: 'attachment',
+          isConfigured: true
+        }}
+        sendCertificateEmail={sendCertificateEmail}
+        setIndividualPdfsData={jest.fn()}
+        detectedEmailColumn="Email"
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Second_Recipient.pdf')).toBeInTheDocument();
+    expect(screen.getByText(/second@example\.com/)).toBeInTheDocument();
+    expect(screen.queryByText(/first@example\.com/)).not.toBeInTheDocument();
+    expect(screen.getByTitle('Email sent!')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Email sent!'));
+    expect(sendCertificateEmail).toHaveBeenCalledWith(
+      0,
+      expect.objectContaining({
+        originalIndex: 1,
+        filename: 'Second_Recipient.pdf'
+      })
+    );
+  });
 });

--- a/__tests__/hooks/useEmailConfig.test.ts
+++ b/__tests__/hooks/useEmailConfig.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from '@testing-library/react';
+import { useEmailConfig } from '@/hooks/useEmailConfig';
+
+describe('useEmailConfig', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ success: true })
+    });
+  });
+
+  it('sends a progressive PDF to its original recipient without ordinary PDF state', async () => {
+    const tableData = [
+      { Name: 'First Recipient', Email: 'first@example.com' },
+      { Name: 'Second Recipient', Email: 'second@example.com' }
+    ];
+    const { result } = renderHook(() =>
+      useEmailConfig({
+        detectedEmailColumn: 'Email',
+        tableData
+      })
+    );
+
+    act(() => {
+      result.current.setEmailConfig({
+        senderName: 'Certificates',
+        subject: 'Your certificate',
+        message: 'Hello [Recipient Name]',
+        deliveryMethod: 'download',
+        isConfigured: true
+      });
+    });
+
+    await act(async () => {
+      await result.current.sendCertificateEmail(0, {
+        filename: 'second.pdf',
+        url: '/generated/second.pdf',
+        originalIndex: 1
+      });
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/send-email',
+      expect.objectContaining({
+        body: expect.any(String)
+      })
+    );
+    const request = (global.fetch as jest.Mock).mock.calls[0][1];
+    expect(JSON.parse(request.body)).toMatchObject({
+      to: 'second@example.com',
+      recipientName: 'Second Recipient',
+      downloadUrl: '/generated/second.pdf',
+      attachmentName: 'second.pdf'
+    });
+    expect(result.current.emailSendingStatus).toEqual({ 1: 'sent' });
+  });
+});

--- a/__tests__/lib/pdf/pdf-queue-filenames.test.ts
+++ b/__tests__/lib/pdf/pdf-queue-filenames.test.ts
@@ -25,4 +25,27 @@ describe('PdfQueueManager filenames', () => {
       'Ada_Lovelace-2.pdf'
     ]);
   });
+
+  it('preserves source row indices when an earlier recipient fails', async () => {
+    const manager = new PdfQueueManager(
+      'session',
+      'template.pdf',
+      {},
+      { width: 600, height: 400 },
+      'individual',
+      { batchSize: 2, maxRetries: 1 }
+    );
+
+    await manager.initializeQueue([{ Name: 'First' }, { Name: 'Second' }], 'Name');
+    await manager.startProcessing();
+    await manager.processNextBatch(async (item) => {
+      if (item.index === 0) throw new Error('first recipient failed');
+      return { path: '/generated/second.pdf', filename: item.filename };
+    });
+
+    expect(manager.getResults()).toMatchObject({
+      files: [{ index: 1, filename: 'Second.pdf', path: '/generated/second.pdf' }],
+      errors: [{ index: 0, error: 'first recipient failed' }]
+    });
+  });
 });

--- a/__tests__/lib/pdf/progressive-results.test.ts
+++ b/__tests__/lib/pdf/progressive-results.test.ts
@@ -1,0 +1,17 @@
+import { mapProgressivePdfFiles } from '@/lib/pdf/progressive-results';
+
+describe('mapProgressivePdfFiles', () => {
+  it('carries the original row index through the API-to-UI adapter', () => {
+    expect(
+      mapProgressivePdfFiles([
+        { index: 1, filename: 'second.pdf', path: '/generated/second.pdf' }
+      ])
+    ).toEqual([
+      {
+        originalIndex: 1,
+        filename: 'second.pdf',
+        url: '/generated/second.pdf'
+      }
+    ]);
+  });
+});

--- a/components/modals/IndividualPdfsModal.tsx
+++ b/components/modals/IndividualPdfsModal.tsx
@@ -126,24 +126,24 @@ export function IndividualPdfsModal({
               <Button
                 size="sm"
                 variant={
-                  emailSendingStatus[index] === 'sent' ? 'default' : 'outline'
+                  emailSendingStatus[rowIndex] === 'sent' ? 'default' : 'outline'
                 }
                 title={
                   !emailAddress
                     ? 'No email address available'
                     : !emailConfig.isConfigured
                       ? 'Configure email settings in Email tab first'
-                      : emailSendingStatus[index] === 'sending'
+                      : emailSendingStatus[rowIndex] === 'sending'
                         ? 'Sending email...'
-                        : emailSendingStatus[index] === 'sent'
+                        : emailSendingStatus[rowIndex] === 'sent'
                           ? 'Email sent!'
-                          : emailSendingStatus[index] === 'error'
+                          : emailSendingStatus[rowIndex] === 'error'
                             ? 'Failed to send email'
                             : 'Send via email'
                 }
                 disabled={
                   !emailAddress ||
-                  emailSendingStatus[index] === 'sending' ||
+                  emailSendingStatus[rowIndex] === 'sending' ||
                   !emailConfig.isConfigured
                 }
                 onClick={() =>
@@ -153,27 +153,27 @@ export function IndividualPdfsModal({
                 style={{
                   backgroundColor: !emailAddress
                     ? 'transparent'
-                    : emailSendingStatus[index] === 'sent'
+                    : emailSendingStatus[rowIndex] === 'sent'
                       ? '#2D6A4F'
-                      : emailSendingStatus[index] === 'error'
+                      : emailSendingStatus[rowIndex] === 'error'
                         ? '#dc2626'
                         : 'transparent',
                   borderColor: !emailAddress
                     ? '#d1d5db'
-                    : emailSendingStatus[index] === 'sent'
+                    : emailSendingStatus[rowIndex] === 'sent'
                       ? '#2D6A4F'
-                      : emailSendingStatus[index] === 'error'
+                      : emailSendingStatus[rowIndex] === 'error'
                         ? '#dc2626'
                         : '#2D6A4F',
                   color: !emailAddress
                     ? '#9ca3af'
-                    : emailSendingStatus[index] === 'sent' ||
-                        emailSendingStatus[index] === 'error'
+                    : emailSendingStatus[rowIndex] === 'sent' ||
+                        emailSendingStatus[rowIndex] === 'error'
                       ? 'white'
                       : '#2D6A4F',
                   cursor: !emailAddress ? 'not-allowed' : 'pointer'
                 }}>
-                {emailSendingStatus[index] === 'sending' ? (
+                {emailSendingStatus[rowIndex] === 'sending' ? (
                   <div className="h-4 w-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
                 ) : (
                   <Mail className="h-4 w-4" />

--- a/hooks/useEmailConfig.ts
+++ b/hooks/useEmailConfig.ts
@@ -5,7 +5,6 @@ import { blobToBase64 } from "@/lib/email/client-attachment-batches";
 export interface UseEmailConfigProps {
   detectedEmailColumn: string | null;
   tableData: TableData[];
-  individualPdfsData: PdfFile[] | null;
 }
 
 export interface UseEmailConfigReturn {
@@ -22,8 +21,7 @@ export interface UseEmailConfigReturn {
 
 export function useEmailConfig({
   detectedEmailColumn,
-  tableData,
-  individualPdfsData
+  tableData
 }: UseEmailConfigProps): UseEmailConfigReturn {
   const [emailConfig, setEmailConfig] = useState<EmailConfig>({
     senderName: "",
@@ -74,13 +72,13 @@ export function useEmailConfig({
   ) => {
     if (
       !detectedEmailColumn ||
-      !individualPdfsData ||
       !emailConfig.isConfigured
     )
       return;
 
     const recipientData = tableData[file.originalIndex ?? index];
     const recipientEmail = recipientData[detectedEmailColumn];
+    const statusKey = file.originalIndex ?? index;
 
     if (!recipientEmail) {
       alert("No email address found for this recipient");
@@ -88,7 +86,7 @@ export function useEmailConfig({
     }
 
     // Update sending status
-    setEmailSendingStatus((prev) => ({ ...prev, [index]: "sending" }));
+    setEmailSendingStatus((prev) => ({ ...prev, [statusKey]: "sending" }));
 
     try {
       // Get recipient name (try common name columns)
@@ -147,7 +145,7 @@ export function useEmailConfig({
       const result = await response.json();
 
       if (response.ok) {
-        setEmailSendingStatus((prev) => ({ ...prev, [index]: "sent" }));
+        setEmailSendingStatus((prev) => ({ ...prev, [statusKey]: "sent" }));
 
         // Mark as emailed in R2 if using cloud storage
         if (
@@ -170,12 +168,12 @@ export function useEmailConfig({
       }
     } catch (error) {
       console.error("Email sending failed:", error);
-      setEmailSendingStatus((prev) => ({ ...prev, [index]: "error" }));
+      setEmailSendingStatus((prev) => ({ ...prev, [statusKey]: "error" }));
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       alert(`Failed to send email: ${errorMessage}`);
     }
-  }, [detectedEmailColumn, individualPdfsData, emailConfig, tableData]);
+  }, [detectedEmailColumn, emailConfig, tableData]);
 
   return {
     emailConfig,

--- a/lib/pdf/progressive-results.ts
+++ b/lib/pdf/progressive-results.ts
@@ -1,0 +1,12 @@
+import type { PdfFile } from '@/types/certificate';
+import type { PdfGenerationResult } from './types';
+
+export function mapProgressivePdfFiles(
+  files: PdfGenerationResult['files']
+): PdfFile[] {
+  return files.map((file) => ({
+    filename: file.filename,
+    url: file.path,
+    originalIndex: file.index
+  }));
+}

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -60,6 +60,7 @@ import { HelpCircle } from "lucide-react";
 import { useSession } from 'next-auth/react';
 import { useProjectMigration } from "@/hooks/useProjectMigration";
 import { useUserTier } from "@/hooks/useUserTier";
+import { mapProgressivePdfFiles } from "@/lib/pdf/progressive-results";
 
 export default function HomePage() {
   // ============================================================================
@@ -351,8 +352,7 @@ export default function HomePage() {
     hasEmailColumn
   } = useEmailConfig({
     detectedEmailColumn,
-    tableData,
-    individualPdfsData
+    tableData
   });
 
   // Dev mode hook (must come after file upload, PDF generation, and email config hooks)
@@ -1003,11 +1003,7 @@ export default function HomePage() {
         individualPdfsData={
           individualPdfsData || clientIndividualPdfsData ||
           (progressivePdfResults && progressivePdfResults.files.length > 0
-            ? progressivePdfResults.files.map((file) => ({
-                filename: file.filename,
-                url: file.path,
-                originalIndex: file.index
-              }))
+            ? mapProgressivePdfFiles(progressivePdfResults.files)
             : null)
         }
         tableData={tableData}


### PR DESCRIPTION
## Summary
- preserve source row identity through progressive result adaptation
- enable progressive single-certificate email delivery without depending on ordinary PDF state
- key email delivery status by original row identity instead of compacted result position
- add queue, adapter, hook, and modal regression tests for an earlier failed recipient

## Verification
- `npm test -- --runInBand --silent` (79 suites, 640 passed, 1 skipped)
- `npm run build`
- `npm run lint` (pre-existing warnings only)
- `git diff --check`
- Claude adversarial review: CLEAN
- Ultra adversarial review: CLEAN
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->