### PR TITLE
security: contain admin storage deletions

### DIFF
--- a/__tests__/lib/storage-manager-security.test.ts
+++ b/__tests__/lib/storage-manager-security.test.ts
@@ -1,0 +1,226 @@
+/** @jest-environment node */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { deleteObjects, ensureSafeStorageKey, isProtectedStorageRoot, listAllObjects } from '@/lib/storage-manager';
+
+describe('storage manager deletion boundaries', () => {
+  let storageDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    storageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-storage-'));
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bamboobot-outside-'));
+    process.env.LOCAL_STORAGE_DIR = storageDir;
+    process.env.STORAGE_PROVIDER = 'local';
+    fs.mkdirSync(path.join(storageDir, 'generated'), { recursive: true });
+    fs.mkdirSync(path.join(storageDir, 'temp_images'), { recursive: true });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.LOCAL_STORAGE_DIR;
+    delete process.env.STORAGE_PROVIDER;
+    fs.rmSync(storageDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  it('rejects non-canonical and cross-platform traversal keys', () => {
+    expect(ensureSafeStorageKey('generated/u_1/file.pdf')).toBe(true);
+    expect(ensureSafeStorageKey('generated/../../secret')).toBe(false);
+    expect(ensureSafeStorageKey('generated/u_1/../secret')).toBe(false);
+    expect(ensureSafeStorageKey('generated\\..\\secret')).toBe(false);
+    expect(ensureSafeStorageKey('/generated/file.pdf')).toBe(false);
+  });
+
+  it('does not delete outside storage through traversal or a symlinked ancestor', async () => {
+    const outsideFile = path.join(outsideDir, 'secret.txt');
+    const outsideLink = path.join(outsideDir, 'link.txt');
+    fs.writeFileSync(outsideFile, 'keep me');
+    fs.symlinkSync(outsideFile, outsideLink);
+    fs.symlinkSync(outsideDir, path.join(storageDir, 'generated', 'outside'));
+
+    const result = await deleteObjects([
+      { key: 'generated/../../secret.txt' },
+      { key: 'generated/../../outside', isPrefix: true },
+      { key: 'generated/outside/secret.txt' },
+      { key: 'generated/outside/link.txt' }
+    ]);
+
+    expect(result.deleted).toEqual([]);
+    expect(result.errors).toEqual([
+      'generated/../../secret.txt',
+      'generated/../../outside',
+      'generated/outside/secret.txt',
+      'generated/outside/link.txt'
+    ]);
+    expect(fs.readFileSync(outsideFile, 'utf8')).toBe('keep me');
+    expect(fs.lstatSync(outsideLink).isSymbolicLink()).toBe(true);
+  });
+
+  it('deletes valid files and never follows symlinks while listing', async () => {
+    const validFile = path.join(storageDir, 'generated', 'valid.pdf');
+    fs.writeFileSync(validFile, 'pdf');
+    fs.writeFileSync(path.join(outsideDir, 'leak.txt'), 'outside');
+    fs.symlinkSync(outsideDir, path.join(storageDir, 'generated', 'outside'));
+
+    expect((await listAllObjects()).map((item) => item.key)).toEqual(['generated/valid.pdf']);
+    await expect(deleteObjects([{ key: 'generated/valid.pdf' }])).resolves.toEqual({
+      deleted: ['generated/valid.pdf'],
+      errors: []
+    });
+    expect(fs.existsSync(validFile)).toBe(false);
+  });
+
+  it('unlinks in-storage symlinks without touching file or directory targets', async () => {
+    const outsideFile = path.join(outsideDir, 'target.txt');
+    const fileLink = path.join(storageDir, 'generated', 'file-link');
+    const directoryLink = path.join(storageDir, 'generated', 'directory-link');
+    const danglingLink = path.join(storageDir, 'generated', 'dangling-link');
+    fs.writeFileSync(outsideFile, 'keep me');
+    fs.symlinkSync(outsideFile, fileLink);
+    fs.symlinkSync(outsideDir, directoryLink);
+    fs.symlinkSync(path.join(outsideDir, 'missing'), danglingLink);
+
+    await expect(deleteObjects([
+      { key: 'generated/file-link' },
+      { key: 'generated/directory-link', isPrefix: true },
+      { key: 'generated/dangling-link' }
+    ])).resolves.toEqual({
+      deleted: [
+        'generated/file-link',
+        'generated/directory-link',
+        'generated/dangling-link'
+      ],
+      errors: []
+    });
+
+    expect(fs.existsSync(fileLink)).toBe(false);
+    expect(fs.existsSync(directoryLink)).toBe(false);
+    expect(fs.existsSync(danglingLink)).toBe(false);
+    expect(fs.readFileSync(outsideFile, 'utf8')).toBe('keep me');
+    expect(fs.existsSync(outsideDir)).toBe(true);
+  });
+
+  it('flags namespace roots as protected and descendants as deletable', () => {
+    expect(isProtectedStorageRoot('generated/')).toBe(true);
+    expect(isProtectedStorageRoot('temp_images/')).toBe(true);
+    expect(isProtectedStorageRoot('generated/u_1/')).toBe(false);
+    expect(isProtectedStorageRoot('temp_images/u_1/img.png')).toBe(false);
+  });
+
+  it('refuses to delete a namespace root even with isPrefix', async () => {
+    const looseFile = path.join(storageDir, 'generated', 'loose.pdf');
+    const nestedFile = path.join(storageDir, 'generated', 'batch-1', 'cert.pdf');
+    const tempFile = path.join(storageDir, 'temp_images', 'u_1', 'img.png');
+    fs.mkdirSync(path.dirname(nestedFile), { recursive: true });
+    fs.mkdirSync(path.dirname(tempFile), { recursive: true });
+    fs.writeFileSync(looseFile, 'loose');
+    fs.writeFileSync(nestedFile, 'nested');
+    fs.writeFileSync(tempFile, 'temp');
+
+    await expect(deleteObjects([
+      { key: 'generated/', isPrefix: true },
+      { key: 'temp_images/', isPrefix: true },
+      { key: 'generated/' },
+      { key: 'temp_images/' }
+    ])).resolves.toEqual({
+      deleted: [],
+      errors: ['generated/', 'temp_images/', 'generated/', 'temp_images/']
+    });
+
+    expect(fs.readFileSync(looseFile, 'utf8')).toBe('loose');
+    expect(fs.readFileSync(nestedFile, 'utf8')).toBe('nested');
+    expect(fs.readFileSync(tempFile, 'utf8')).toBe('temp');
+  });
+
+  it('refuses a prefix delete that resolves onto a namespace root via an intermediate symlink', async () => {
+    const keepFile = path.join(storageDir, 'temp_images', 'keep.png');
+    fs.writeFileSync(keepFile, 'keep');
+    // Attacker-planted in-storage symlink whose non-final component points at
+    // the storage base, so `generated/up/temp_images` resolves to the
+    // temp_images root.
+    fs.symlinkSync(storageDir, path.join(storageDir, 'generated', 'up'));
+
+    await expect(deleteObjects([
+      { key: 'generated/up/temp_images', isPrefix: true },
+      { key: 'generated/up/generated', isPrefix: true }
+    ])).resolves.toEqual({
+      deleted: [],
+      errors: ['generated/up/temp_images', 'generated/up/generated']
+    });
+
+    expect(fs.existsSync(path.join(storageDir, 'temp_images'))).toBe(true);
+    expect(fs.readFileSync(keepFile, 'utf8')).toBe('keep');
+  });
+
+  it('protects a namespace root against a case-variant symlink route on case-insensitive filesystems', async () => {
+    const keepFile = path.join(storageDir, 'temp_images', 'keep.png');
+    fs.writeFileSync(keepFile, 'keep');
+    fs.symlinkSync(storageDir, path.join(storageDir, 'generated', 'up'));
+
+    // On a case-insensitive filesystem (macOS APFS) `Temp_Images` resolves to
+    // the real `temp_images` directory; on a case-sensitive filesystem the
+    // path simply does not exist and the delete is a no-op. Either way the
+    // root and its contents must survive, and nothing may be reported deleted.
+    const result = await deleteObjects([
+      { key: 'generated/up/Temp_Images', isPrefix: true },
+      { key: 'generated/up/GENERATED', isPrefix: true }
+    ]);
+
+    expect(result.deleted).toEqual([]);
+    expect(fs.existsSync(path.join(storageDir, 'temp_images'))).toBe(true);
+    expect(fs.existsSync(path.join(storageDir, 'generated'))).toBe(true);
+    expect(fs.readFileSync(keepFile, 'utf8')).toBe('keep');
+  });
+
+  it('still deletes a canonical descendant prefix recursively', async () => {
+    const batchDir = path.join(storageDir, 'generated', 'batch-1');
+    const batchFile = path.join(batchDir, 'cert.pdf');
+    const siblingFile = path.join(storageDir, 'generated', 'keep.pdf');
+    const tempUserDir = path.join(storageDir, 'temp_images', 'u_1');
+    const tempFile = path.join(tempUserDir, 'img.png');
+    fs.mkdirSync(batchDir, { recursive: true });
+    fs.mkdirSync(tempUserDir, { recursive: true });
+    fs.writeFileSync(batchFile, 'batch');
+    fs.writeFileSync(siblingFile, 'keep');
+    fs.writeFileSync(tempFile, 'temp');
+
+    await expect(deleteObjects([
+      { key: 'generated/batch-1/', isPrefix: true },
+      { key: 'temp_images/u_1/', isPrefix: true }
+    ])).resolves.toEqual({
+      deleted: ['generated/batch-1/', 'temp_images/u_1/'],
+      errors: []
+    });
+
+    expect(fs.existsSync(batchDir)).toBe(false);
+    expect(fs.existsSync(tempUserDir)).toBe(false);
+    expect(fs.readFileSync(siblingFile, 'utf8')).toBe('keep');
+  });
+
+  it('reports a prefix match skipped by the final safety check as an error', async () => {
+    const exactPrefix = path.join(storageDir, 'generated', 'batch');
+    const matchingFile = path.join(storageDir, 'generated', 'batch-extra.pdf');
+    fs.writeFileSync(exactPrefix, 'first');
+    fs.writeFileSync(matchingFile, 'second');
+    const originalLstat = fs.lstatSync.bind(fs);
+    let matchingFileChecks = 0;
+    jest.spyOn(fs, 'lstatSync').mockImplementation((candidate) => {
+      if (candidate === matchingFile && ++matchingFileChecks === 2) {
+        const error = new Error('simulated removal race') as NodeJS.ErrnoException;
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return originalLstat(candidate);
+    });
+
+    await expect(deleteObjects([{ key: 'generated/batch', isPrefix: true }])).resolves.toEqual({
+      deleted: ['generated/batch'],
+      errors: ['generated/batch-extra.pdf']
+    });
+    expect(fs.existsSync(exactPrefix)).toBe(false);
+    expect(fs.existsSync(matchingFile)).toBe(true);
+  });
+});

--- a/lib/storage-manager.ts
+++ b/lib/storage-manager.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import storageConfig from './storage-config';
 import { listFiles as listR2Files, deleteFromR2 } from './r2-client';
 import { listAllS3Objects, deleteFromS3 } from './s3-client';
-import { getGeneratedDir, getLocalStorageDir, getTempImagesDir } from './paths';
+import { getGeneratedDir, getLocalStorageDir, getTempImagesDir, resolvePathWithin } from './paths';
 
 export type StorageProvider = 'local' | 'cloudflare-r2' | 'amazon-s3';
 
@@ -20,9 +20,59 @@ export function getProvider(): StorageProvider {
   return 'local';
 }
 
-function ensureSafeKey(key: string): boolean {
-  // Only allow keys within our app namespaces
-  return key.startsWith('generated/') || key.startsWith('temp_images/');
+export function ensureSafeStorageKey(key: unknown): key is string {
+  if (typeof key !== 'string' || key.includes('\\') || key.includes('\0')) return false;
+  if (!key.startsWith('generated/') && !key.startsWith('temp_images/')) return false;
+  return path.posix.normalize(key) === key;
+}
+
+// The namespace roots themselves are never valid deletion targets: a prefix
+// delete on one would wipe the entire namespace, far more than any UI
+// selection represents. Only canonical descendants may be deleted.
+export function isProtectedStorageRoot(key: string): boolean {
+  return key === 'generated/' || key === 'temp_images/';
+}
+
+function isWithinRealStorage(candidate: string, allowBase = false): boolean {
+  const realBase = fs.realpathSync(getLocalStorageDir());
+  const realCandidate = fs.realpathSync(candidate);
+  const relative = path.relative(realBase, realCandidate);
+  return (allowBase || !!relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+// A canonical key can still resolve onto a namespace root when an in-storage
+// symlink is used as an intermediate path component (e.g.
+// `generated/<link-to-base>/temp_images`). The lexical isProtectedStorageRoot
+// guard cannot see that, so recursive deletes must also reject any path that
+// lands on the storage base or a namespace root. Identity is compared by
+// device + inode rather than by resolved path string: on case-insensitive
+// filesystems (macOS APFS) a case-variant final component such as
+// `Temp_Images` realpaths to a differently-cased string yet points at the
+// same directory, which a string comparison would miss.
+function resolvesToProtectedRoot(candidate: string): boolean {
+  let target: fs.Stats;
+  try {
+    target = fs.statSync(candidate);
+  } catch {
+    return false;
+  }
+  return [getLocalStorageDir(), getGeneratedDir(), getTempImagesDir()].some((root) => {
+    try {
+      const rootStat = fs.statSync(root);
+      return rootStat.dev === target.dev && rootStat.ino === target.ino;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function lstatIfPresent(candidate: string): fs.Stats | null {
+  try {
+    return fs.lstatSync(candidate);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
 }
 
 // Local helpers
@@ -36,7 +86,8 @@ function walkLocal(dir: string, basePrefix: string): StorageItem[] {
     const entries = fs.readdirSync(current);
     for (const name of entries) {
       const full = path.join(current, name);
-      const stat = fs.statSync(full);
+      const stat = fs.lstatSync(full);
+      if (stat.isSymbolicLink()) continue;
       if (stat.isDirectory()) {
         stack.push(full);
         continue;
@@ -58,14 +109,14 @@ export async function listAllObjects(prefix?: string): Promise<StorageItem[]> {
   if (provider === 'cloudflare-r2' && storageConfig.isR2Enabled) {
     const files = await listR2Files(prefix);
     return files
-      .filter(f => f.key && ensureSafeKey(f.key))
+      .filter(f => f.key && ensureSafeStorageKey(f.key))
       .map(f => ({ key: f.key, size: f.size || 0, lastModified: f.lastModified?.toISOString() }));
   }
 
   if (provider === 'amazon-s3' && storageConfig.isS3Enabled) {
     const files = await listAllS3Objects(prefix);
     return files
-      .filter(f => f.key && ensureSafeKey(f.key))
+      .filter(f => f.key && ensureSafeStorageKey(f.key))
       .map(f => ({ key: f.key, size: f.size || 0, lastModified: f.lastModified?.toISOString() }));
   }
 
@@ -80,12 +131,21 @@ export async function listAllObjects(prefix?: string): Promise<StorageItem[]> {
   return prefix ? results.filter(i => i.key.startsWith(prefix)) : results;
 }
 
-export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boolean }>): Promise<{ deleted: string[]; errors: string[] }>{
+export async function deleteObjects(actions: Array<{ key?: unknown; isPrefix?: unknown }>): Promise<{ deleted: string[]; errors: string[] }>{
   const provider = getProvider();
   const deleted: string[] = [];
   const errors: string[] = [];
 
-  const safeActions = actions.filter(a => ensureSafeKey(a.key));
+  const safeActions = actions.filter((a): a is { key: string; isPrefix?: boolean } => {
+    if (
+      a &&
+      ensureSafeStorageKey(a.key) &&
+      !isProtectedStorageRoot(a.key) &&
+      (a.isPrefix === undefined || typeof a.isPrefix === 'boolean')
+    ) return true;
+    errors.push(a && typeof a.key === 'string' ? a.key : '<invalid key>');
+    return false;
+  });
 
   if (provider === 'cloudflare-r2' && storageConfig.isR2Enabled) {
     for (const a of safeActions) {
@@ -93,6 +153,10 @@ export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boo
         if (a.isPrefix) {
           const files = await listR2Files(a.key);
           for (const f of files) {
+            if (!ensureSafeStorageKey(f.key) || !f.key.startsWith(a.key)) {
+              errors.push(String(f.key));
+              continue;
+            }
             await deleteFromR2(f.key);
             deleted.push(f.key);
           }
@@ -113,6 +177,10 @@ export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boo
         if (a.isPrefix) {
           const files = await listAllS3Objects(a.key);
           for (const f of files) {
+            if (!ensureSafeStorageKey(f.key) || !f.key.startsWith(a.key)) {
+              errors.push(String(f.key));
+              continue;
+            }
             await deleteFromS3(f.key);
             deleted.push(f.key);
           }
@@ -130,12 +198,35 @@ export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boo
   // Local deletions
   for (const a of safeActions) {
     try {
-      const full = path.join(getLocalStorageDir(), a.key);
+      const full = resolvePathWithin(getLocalStorageDir(), a.key);
+      if (!full) {
+        errors.push(a.key);
+        continue;
+      }
       if (a.isPrefix) {
         // Delete everything under the directory
-        if (fs.existsSync(full)) {
-          const stat = fs.statSync(full);
+        const stat = lstatIfPresent(full);
+        if (stat) {
+          if (stat.isSymbolicLink()) {
+            if (!isWithinRealStorage(path.dirname(full), true)) {
+              errors.push(a.key);
+              continue;
+            }
+            fs.unlinkSync(full);
+            deleted.push(a.key);
+            continue;
+          }
+          if (!isWithinRealStorage(full)) {
+            errors.push(a.key);
+            continue;
+          }
           if (stat.isDirectory()) {
+            // Refuse to recurse into the storage base or a namespace root,
+            // even when a symlinked path component resolves onto one.
+            if (resolvesToProtectedRoot(full)) {
+              errors.push(a.key);
+              continue;
+            }
             // Recursively remove directory
             fs.rmSync(full, { recursive: true, force: true });
           } else {
@@ -143,17 +234,34 @@ export async function deleteObjects(actions: Array<{ key: string; isPrefix?: boo
             // Fallback: walk both roots and remove filtered
             const all = await listAllObjects(a.key);
             for (const f of all) {
-              const abs = path.join(getLocalStorageDir(), f.key);
-              if (fs.existsSync(abs)) fs.rmSync(abs, { force: true });
-              deleted.push(f.key);
+              const abs = resolvePathWithin(getLocalStorageDir(), f.key);
+              const listedStat = abs ? lstatIfPresent(abs) : null;
+              if (abs && listedStat && !listedStat.isSymbolicLink() && isWithinRealStorage(abs)) {
+                fs.rmSync(abs, { force: true });
+                deleted.push(f.key);
+              } else {
+                errors.push(f.key);
+              }
             }
             continue;
           }
           deleted.push(a.key);
         }
       } else {
-        if (fs.existsSync(full)) {
-          fs.rmSync(full, { force: true });
+        const stat = lstatIfPresent(full);
+        if (stat) {
+          const contained = stat.isSymbolicLink()
+            ? isWithinRealStorage(path.dirname(full), true)
+            : isWithinRealStorage(full);
+          if (!contained) {
+            errors.push(a.key);
+            continue;
+          }
+          if (stat.isSymbolicLink()) {
+            fs.unlinkSync(full);
+          } else {
+            fs.rmSync(full, { force: true });
+          }
           deleted.push(a.key);
         }
       }

--- a/pages/admin/storage.tsx
+++ b/pages/admin/storage.tsx
@@ -131,23 +131,42 @@ export default function StoragePage() {
     return `/api/admin/storage/get?key=${encodeURIComponent(key)}`;
   }
 
-  async function executeDeletion() {
+  // Accepts an explicit selection so inline per-row Delete buttons can pass the
+  // just-clicked key directly. Relying on `selected` state here would read a
+  // stale value, because React has not yet applied the setSelected update that
+  // runs in the same click handler.
+  async function executeDeletion(selectionOverride?: Record<string, boolean>) {
     if (!data) return;
+    const sel = selectionOverride ?? selected;
     const items: Array<{ key: string; isPrefix?: boolean }> = [];
 
     if (view === 'files') {
-      for (const it of filteredFiles) if (selected[it.key]) items.push({ key: it.key });
+      for (const it of filteredFiles) if (sel[it.key]) items.push({ key: it.key });
     }
     if (view === 'largest') {
-      for (const it of data.aggregates.largest) if (selected[it.key]) items.push({ key: it.key });
+      for (const it of data.aggregates.largest) if (sel[it.key]) items.push({ key: it.key });
     }
     if (view === 'folders') {
-      for (const g of folderGroups) if (selected[`prefix:${g.prefix}`]) items.push({ key: g.prefix, isPrefix: true });
+      for (const g of folderGroups) {
+        if (!sel[`prefix:${g.prefix}`]) continue;
+        if (g.prefix === 'generated/' || g.prefix === 'temp_images/') {
+          // The root group only aggregates files sitting directly under the
+          // namespace root; the server refuses recursive root deletes, so
+          // send those files individually instead.
+          for (const it of data.items) {
+            if (!it.key.startsWith(g.prefix)) continue;
+            if (it.key.slice(g.prefix.length).includes('/')) continue;
+            items.push({ key: it.key });
+          }
+        } else {
+          items.push({ key: g.prefix, isPrefix: true });
+        }
+      }
     }
     if (view === 'date') {
       const keysToDelete: string[] = [];
       const dateSelected = new Set<string>();
-      for (const g of dateGroups) if (selected[`date:${g.date}`]) dateSelected.add(g.date);
+      for (const g of dateGroups) if (sel[`date:${g.date}`]) dateSelected.add(g.date);
       if (dateSelected.size > 0) {
         for (const it of data.items) {
           const d = (it.lastModified ? new Date(it.lastModified) : null);
@@ -255,7 +274,7 @@ export default function StoragePage() {
           <div className="flex items-center gap-2">
             <button className="px-3 py-1.5 text-sm border rounded" onClick={()=>toggleAllCurrentView(true)}>Select All in View</button>
             <button className="px-3 py-1.5 text-sm border rounded" onClick={()=>toggleAllCurrentView(false)}>Clear Selection</button>
-            <button className="px-3 py-1.5 text-sm rounded bg-red-600 text-white" onClick={executeDeletion}>Delete Selected</button>
+            <button className="px-3 py-1.5 text-sm rounded bg-red-600 text-white" onClick={()=>executeDeletion()}>Delete Selected</button>
           </div>
         </div>
 
@@ -315,7 +334,7 @@ export default function StoragePage() {
                     <td className="px-4 py-2 text-sm">{g.count}</td>
                     <td className="px-4 py-2 text-sm">{formatBytes(g.size)}</td>
                     <td className="px-4 py-2 text-right">
-                      <button className="px-3 py-1.5 text-sm rounded bg-red-600 text-white" onClick={()=>{ setSelected(s=>({ ...s, [`prefix:${g.prefix}`]: true })); executeDeletion(); }}>Delete</button>
+                      <button className="px-3 py-1.5 text-sm rounded bg-red-600 text-white" onClick={()=>executeDeletion({ [`prefix:${g.prefix}`]: true })}>Delete</button>
                     </td>
                   </tr>
                 ))}
@@ -344,7 +363,7 @@ export default function StoragePage() {
                     <td className="px-4 py-2 text-sm">{g.count}</td>
                     <td className="px-4 py-2 text-sm">{formatBytes(g.size)}</td>
                     <td className="px-4 py-2 text-right">
-                      <button className="px-3 py-1.5 text-sm rounded bg-red-600 text-white" onClick={()=>{ setSelected(s=>({ ...s, [`date:${g.date}`]: true })); executeDeletion(); }}>Delete</button>
+                      <button className="px-3 py-1.5 text-sm rounded bg-red-600 text-white" onClick={()=>executeDeletion({ [`date:${g.date}`]: true })}>Delete</button>
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Summary
- require canonical storage keys within generated/temp namespaces
- enforce lexical and realpath containment for local deletes
- avoid following symlinks while listing or deleting; safely unlink in-root terminal links
- defensively validate cloud prefix listing results before deletion
- add traversal, prefix, ancestor-symlink, terminal-symlink, dangling-link, and valid-delete tests

## Verification
- `npm test -- --runInBand --silent` (80 suites, 644 passed, 1 skipped)
- `npm run build`
- `npm run lint` (pre-existing warnings only)
- `git diff --check`
- Claude adversarial review: CLEAN
- Ultra adversarial review: CLEAN
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->