### PR TITLE
fix: preserve retention for emailed files in cloud storage

### DIFF
--- a/__tests__/lib/file-metadata.test.ts
+++ b/__tests__/lib/file-metadata.test.ts
@@ -1,0 +1,61 @@
+import { normalizeStoredMetadata, readFileMetadata } from '@/lib/storage/file-metadata';
+
+describe('storage file metadata parsing', () => {
+  it('reads emailSent and downloadCount from lowercased provider keys', () => {
+    // S3/R2 return custom metadata keys lowercased.
+    const raw = {
+      type: 'bulk',
+      created: '2026-01-01T00:00:00.000Z',
+      retention: '7d',
+      emailsent: 'true',
+      downloadcount: '3',
+    };
+    const parsed = readFileMetadata(raw);
+    expect(parsed).toEqual({
+      type: 'bulk',
+      created: '2026-01-01T00:00:00.000Z',
+      retention: '7d',
+      emailSent: 'true',
+      downloadCount: '3',
+    });
+  });
+
+  it('still reads camelCase keys (idempotent)', () => {
+    const parsed = readFileMetadata({
+      type: 'individual',
+      created: '2026-01-02T00:00:00.000Z',
+      retention: '90d',
+      emailSent: 'true',
+    });
+    expect(parsed?.emailSent).toBe('true');
+    expect(parsed?.retention).toBe('90d');
+  });
+
+  it('treats a missing emailSent flag as false and defaults sensibly', () => {
+    const parsed = readFileMetadata({ created: '2026-01-03T00:00:00.000Z' });
+    expect(parsed?.emailSent).toBe('false');
+    expect(parsed?.retention).toBe('permanent');
+    expect(parsed?.type).toBe('template');
+    expect(parsed?.downloadCount).toBe('0');
+  });
+
+  it('rejects unknown retention/type values, falling back to safe defaults', () => {
+    const parsed = readFileMetadata({ retention: 'forever', type: 'weird' });
+    expect(parsed?.retention).toBe('permanent');
+    expect(parsed?.type).toBe('template');
+  });
+
+  it('returns null when there is no metadata', () => {
+    expect(readFileMetadata(undefined)).toBeNull();
+    expect(readFileMetadata(null)).toBeNull();
+  });
+
+  it('lowercases all keys, letting a later update overwrite a stored flag', () => {
+    const merged = {
+      ...normalizeStoredMetadata({ emailsent: 'false', retention: '7d', created: 'x' }),
+      ...normalizeStoredMetadata({ emailSent: 'true', retention: '90d' }),
+    };
+    // No colliding emailsent/emailSent pair survives the merge.
+    expect(merged).toEqual({ emailsent: 'true', retention: '90d', created: 'x' });
+  });
+});

--- a/lib/r2-client.ts
+++ b/lib/r2-client.ts
@@ -7,6 +7,7 @@ import {
   HeadObjectCommand 
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { readFileMetadata } from '@/lib/storage/file-metadata';
 
 // Initialize R2 client (S3-compatible)
 const r2Client = new S3Client({
@@ -141,7 +142,9 @@ export async function getFileMetadata(key: string): Promise<FileMetadata | null>
     });
     
     const response = await r2Client.send(command);
-    return response.Metadata as unknown as FileMetadata;
+    // Providers return custom metadata keys lowercased, so parse
+    // case-insensitively rather than casting the raw record.
+    return readFileMetadata(response.Metadata);
   } catch (error) {
     console.error('Error getting file metadata:', error);
     return null;

--- a/lib/s3-client.ts
+++ b/lib/s3-client.ts
@@ -7,6 +7,7 @@ import {
   HeadObjectCommand 
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { normalizeStoredMetadata, readFileMetadata } from '@/lib/storage/file-metadata';
 
 // Initialize S3 client
 export const s3Client = new S3Client({
@@ -224,13 +225,15 @@ export async function updateS3Metadata(key: string, metadata: Partial<FileMetada
   });
   
   const headResponse = await s3Client.send(headCommand);
-  const currentMetadata = headResponse.Metadata || {};
-  
-  // Merge metadata
+
+  // S3 stores custom metadata keys lowercased. Lowercase both the existing
+  // metadata and the incoming update before merging so an update to e.g.
+  // `emailSent` overwrites the stored `emailsent` instead of adding a second,
+  // colliding key that the service would silently drop.
   const newMetadata = {
-    ...currentMetadata,
-    ...metadata,
-  } as Record<string, string>;
+    ...normalizeStoredMetadata(headResponse.Metadata),
+    ...normalizeStoredMetadata(metadata as Record<string, string>),
+  };
   
   // Get the object content
   const getCommand = new GetObjectCommand({
@@ -280,7 +283,13 @@ export async function cleanupExpiredS3Files(dryRun: boolean = false): Promise<{
 
   for (const obj of objects) {
     try {
-      const metadata = obj.metadata || {};
+      // Providers return custom metadata keys lowercased, so parse
+      // case-insensitively; a camelCase read of emailSent would always miss.
+      const metadata = readFileMetadata(obj.metadata) || {
+        retention: 'permanent' as const,
+        created: '',
+        type: 'template' as const,
+      };
       const created = metadata.created ? new Date(metadata.created) : obj.lastModified;
       const retention = metadata.retention || 'permanent';
       const emailSent = metadata.emailSent === 'true';

--- a/lib/storage/file-metadata.ts
+++ b/lib/storage/file-metadata.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared representation and parsing for the custom object metadata attached to
+ * files stored in S3-compatible providers (Amazon S3, Cloudflare R2).
+ *
+ * Both providers store user metadata keys **lowercased** and return them
+ * lowercased from HeadObject/ListObjects. Reading a camelCase key such as
+ * `metadata.emailSent` therefore silently misses the stored `emailsent` value,
+ * which previously caused emailed files to be treated as not-emailed and
+ * deleted at their base retention instead of having retention extended.
+ */
+
+export interface FileMetadata {
+  type: 'preview' | 'individual' | 'bulk' | 'template';
+  created: string;
+  retention: '24h' | '7d' | '90d' | 'permanent';
+  emailSent?: 'true' | 'false';
+  downloadCount?: string;
+}
+
+const RETENTIONS: ReadonlyArray<FileMetadata['retention']> = ['24h', '7d', '90d', 'permanent'];
+const TYPES: ReadonlyArray<FileMetadata['type']> = ['preview', 'individual', 'bulk', 'template'];
+
+/**
+ * Lowercase every key of a raw provider metadata record so lookups are
+ * case-insensitive regardless of how the value was originally written.
+ */
+export function normalizeStoredMetadata(
+  raw?: Record<string, string> | null
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw ?? {})) {
+    out[key.toLowerCase()] = value;
+  }
+  return out;
+}
+
+/**
+ * Parse raw provider metadata into a typed FileMetadata, reading each field by
+ * its lowercased key. Returns null when no metadata is present.
+ */
+export function readFileMetadata(
+  raw?: Record<string, string> | null
+): FileMetadata | null {
+  if (!raw) return null;
+  const m = normalizeStoredMetadata(raw);
+  const type = TYPES.includes(m.type as FileMetadata['type'])
+    ? (m.type as FileMetadata['type'])
+    : 'template';
+  const retention = RETENTIONS.includes(m.retention as FileMetadata['retention'])
+    ? (m.retention as FileMetadata['retention'])
+    : 'permanent';
+  return {
+    type,
+    created: m.created ?? '',
+    retention,
+    emailSent: m.emailsent === 'true' ? 'true' : 'false',
+    downloadCount: m.downloadcount ?? '0',
+  };
+}


### PR DESCRIPTION
## Summary

Fixes a data-retention bug: emailed certificates were being deleted from cloud storage instead of being retained.

## Root cause

S3 and Cloudflare R2 store custom object metadata keys **lowercased** and return them lowercased from `HeadObject`/`ListObjects`. The retention cleanup read the emailed marker as camelCase `metadata.emailSent`, which never matched the stored `emailsent`. As a result the "email sent → skip deletion / extend retention" rule never fired, and emailed certificates were purged once their retention window elapsed — defeating the documented *"individual certificates: 90 days, extended if emailed"* policy.

A second, related bug: `updateS3Metadata` (used by `markAsEmailedS3`) merged the incoming camelCase update on top of the already-lowercased stored metadata, producing a colliding `emailsent`/`emailSent` pair that S3 silently drops — so even the write side of the emailed flag was unreliable.

## Fix

- New shared helper `lib/storage/file-metadata.ts` (`readFileMetadata` / `normalizeStoredMetadata`) parses provider metadata case-insensitively.
- `lib/r2-client.ts` `getFileMetadata` and `lib/s3-client.ts` cleanup both read through the normalized parser, so the `emailSent` override now fires and emailed files are kept.
- `updateS3Metadata` lowercases both sides before merging, so an update reliably overwrites the stored flag with no colliding key.

## Validation

- New unit tests (`__tests__/lib/file-metadata.test.ts`) cover lowercased provider keys, camelCase idempotence, missing flags, unknown retention/type fallback, and the merge-overwrite behaviour.
- `npm test -- --runInBand` — 81 suites, 656 passed, 1 skipped
- `npm run build` / `npm run lint` / `git diff --check` — clean (pre-existing lint warnings only)
- Adversarial review traced both provider lifecycles end-to-end with a mocked client returning lowercased keys: emailed bulk PDF **kept**, non-emailed stale PDF **deleted**, `created`/`downloadCount` preserved across the R2 re-upload, no colliding S3 keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->