### PR TITLE
security: require authentication for dev-cleanup and storage-stats endpoints

### DIFF
--- a/__tests__/api/dev-cleanup-auth.test.ts
+++ b/__tests__/api/dev-cleanup-auth.test.ts
@@ -1,0 +1,94 @@
+/** @jest-environment node */
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({ __esModule: true, authOptions: {}, default: jest.fn() }));
+jest.mock('next-auth', () => ({ __esModule: true, default: jest.fn(() => jest.fn()), getServerSession: jest.fn() }));
+jest.mock('@/lib/server/tiers', () => ({ detectUserTier: jest.fn() }));
+
+import handler from '@/pages/api/dev-cleanup';
+import httpMocks from 'node-mocks-http';
+
+const { getServerSession } = require('next-auth');
+const { detectUserTier } = require('@/lib/server/tiers');
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_REQUIRE_AUTH = process.env.REQUIRE_AUTH;
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', { value, configurable: true, writable: true, enumerable: true });
+}
+
+function run(method = 'POST', body: unknown = { target: 'temp' }) {
+  const req = httpMocks.createRequest({ method, body });
+  const res = httpMocks.createResponse();
+  return handler(req as any, res as any).then(() => res);
+}
+
+describe('dev-cleanup authentication', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.REQUIRE_AUTH;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: ORIGINAL_NODE_ENV, configurable: true, writable: true, enumerable: true });
+    if (ORIGINAL_REQUIRE_AUTH === undefined) delete process.env.REQUIRE_AUTH;
+    else process.env.REQUIRE_AUTH = ORIGINAL_REQUIRE_AUTH;
+  });
+
+  it('rejects unauthenticated requests in production with 401', async () => {
+    setNodeEnv('production');
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).toBe(401);
+    expect(detectUserTier).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-super-admin session in production with 403', async () => {
+    setNodeEnv('production');
+    getServerSession.mockResolvedValue({ user: { id: 'u1', email: 'user@example.com' } });
+    detectUserTier.mockReturnValue('free');
+    const res = await run();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('requires a session outside development even when auth is not enforced (e.g. test env)', async () => {
+    setNodeEnv('test');
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('requires a session in development when auth is explicitly enforced (REQUIRE_AUTH=true)', async () => {
+    setNodeEnv('development');
+    process.env.REQUIRE_AUTH = 'true';
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows an authenticated non-admin session in development with auth enforced', async () => {
+    setNodeEnv('development');
+    process.env.REQUIRE_AUTH = 'true';
+    getServerSession.mockResolvedValue({ user: { id: 'u1', email: 'dev@example.com' } });
+    detectUserTier.mockReturnValue('free');
+    const res = await run();
+    expect(res.statusCode).not.toBe(401);
+    expect(res.statusCode).not.toBe(403);
+  });
+
+  it('allows the open development mode (auth not enforced) so the dev StorageMonitor works', async () => {
+    setNodeEnv('development');
+    delete process.env.REQUIRE_AUTH; // default dev: isAuthenticationRequired() === false
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    // No session required in open dev mode; must not be blocked by auth.
+    expect(res.statusCode).not.toBe(401);
+    expect(res.statusCode).not.toBe(403);
+    expect(getServerSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-POST methods', async () => {
+    setNodeEnv('development');
+    const res = await run('GET');
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/__tests__/api/storage-stats-auth.test.ts
+++ b/__tests__/api/storage-stats-auth.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+jest.mock('@/pages/api/auth/[...nextauth]', () => ({ __esModule: true, authOptions: {}, default: jest.fn() }));
+jest.mock('next-auth', () => ({ __esModule: true, default: jest.fn(() => jest.fn()), getServerSession: jest.fn() }));
+jest.mock('@/lib/server/tiers', () => ({ detectUserTier: jest.fn() }));
+
+import handler from '@/pages/api/storage-stats';
+import httpMocks from 'node-mocks-http';
+
+const { getServerSession } = require('next-auth');
+const { detectUserTier } = require('@/lib/server/tiers');
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_REQUIRE_AUTH = process.env.REQUIRE_AUTH;
+
+function setNodeEnv(value: string) {
+  Object.defineProperty(process.env, 'NODE_ENV', { value, configurable: true, writable: true, enumerable: true });
+}
+
+function run(method = 'GET') {
+  const req = httpMocks.createRequest({ method });
+  const res = httpMocks.createResponse();
+  return handler(req as any, res as any).then(() => res);
+}
+
+describe('storage-stats authentication', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    delete process.env.REQUIRE_AUTH;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process.env, 'NODE_ENV', { value: ORIGINAL_NODE_ENV, configurable: true, writable: true, enumerable: true });
+    if (ORIGINAL_REQUIRE_AUTH === undefined) delete process.env.REQUIRE_AUTH;
+    else process.env.REQUIRE_AUTH = ORIGINAL_REQUIRE_AUTH;
+  });
+
+  it('rejects unauthenticated requests in production with 401', async () => {
+    setNodeEnv('production');
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a non-super-admin in production with 403', async () => {
+    setNodeEnv('production');
+    getServerSession.mockResolvedValue({ user: { id: 'u1', email: 'user@example.com' } });
+    detectUserTier.mockReturnValue('free');
+    const res = await run();
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('requires a session outside development even when auth is not enforced', async () => {
+    setNodeEnv('test');
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('requires a session in development when auth is enforced (REQUIRE_AUTH=true)', async () => {
+    setNodeEnv('development');
+    process.env.REQUIRE_AUTH = 'true';
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('allows the open development mode (auth not enforced) so the dev StorageMonitor works', async () => {
+    setNodeEnv('development');
+    delete process.env.REQUIRE_AUTH;
+    getServerSession.mockResolvedValue(null);
+    const res = await run();
+    expect(res.statusCode).not.toBe(401);
+    expect(res.statusCode).not.toBe(403);
+    expect(getServerSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-GET methods', async () => {
+    setNodeEnv('development');
+    const res = await run('POST');
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/pages/api/dev-cleanup.ts
+++ b/pages/api/dev-cleanup.ts
@@ -6,6 +6,7 @@ import { formatBytes } from '@/lib/format';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { detectUserTier } from '@/lib/server/tiers';
+import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 
 interface CleanupResult {
   deletedFiles: number;
@@ -135,24 +136,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // Allow in development mode OR for super admins in production
+  // This endpoint performs destructive, unfiltered deletion of stored files.
+  // Allow unauthenticated access ONLY in a local development setup that is not
+  // enforcing authentication (the app's open dev mode, where the in-app
+  // StorageMonitor tool runs without a session). In every other case — any
+  // deployment that enforces auth, and any non-development environment —
+  // require a valid session, and super admin outside development.
+  // getServerSession validates JWT token expiry and signature internally.
   const isDevelopment = process.env.NODE_ENV === 'development';
-
-  if (!isDevelopment) {
-    // Check if user is super admin
+  if (isAuthenticationRequired() || !isDevelopment) {
     const session = await getServerSession(req, res, authOptions);
-
-    // Validate session exists and has required user data
-    // getServerSession validates JWT token expiry and signature internally
     if (!session || !session.user || !session.user.email || !session.user.id) {
       res.status(401).json({ error: 'Unauthorized - valid session required' });
       return;
     }
-
-    const userTier = detectUserTier(session.user.email);
-    if (userTier !== 'super_admin') {
-      res.status(403).json({ error: 'Only available for super admins in production' });
-      return;
+    if (!isDevelopment) {
+      const userTier = detectUserTier(session.user.email);
+      if (userTier !== 'super_admin') {
+        res.status(403).json({ error: 'Only available for super admins in production' });
+        return;
+      }
     }
   }
 

--- a/pages/api/storage-stats.ts
+++ b/pages/api/storage-stats.ts
@@ -5,6 +5,7 @@ import { getTempImagesDir, getGeneratedDir } from '@/lib/paths';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/pages/api/auth/[...nextauth]';
 import { detectUserTier } from '@/lib/server/tiers';
+import { isAuthenticationRequired } from '@/lib/auth/runtime-policy';
 
 interface FileInfo {
   name: string;
@@ -147,24 +148,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // Allow in development mode OR for super admins in production
+  // This endpoint discloses filesystem storage details. Allow unauthenticated
+  // access ONLY in a local development setup that is not enforcing
+  // authentication (the app's open dev mode, where the in-app StorageMonitor
+  // tool runs without a session). In every other case — any deployment that
+  // enforces auth, and any non-development environment — require a valid
+  // session, and super admin outside development.
+  // getServerSession validates JWT token expiry and signature internally.
   const isDevelopment = process.env.NODE_ENV === 'development';
-
-  if (!isDevelopment) {
-    // Check if user is super admin
+  if (isAuthenticationRequired() || !isDevelopment) {
     const session = await getServerSession(req, res, authOptions);
-
-    // Validate session exists and has required user data
-    // getServerSession validates JWT token expiry and signature internally
     if (!session || !session.user || !session.user.email || !session.user.id) {
       res.status(401).json({ error: 'Unauthorized - valid session required' });
       return;
     }
-
-    const userTier = detectUserTier(session.user.email);
-    if (userTier !== 'super_admin') {
-      res.status(403).json({ error: 'Only available for super admins in production' });
-      return;
+    if (!isDevelopment) {
+      const userTier = detectUserTier(session.user.email);
+      if (userTier !== 'super_admin') {
+        res.status(403).json({ error: 'Only available for super admins in production' });
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

`/api/dev-cleanup` performs destructive, unfiltered deletion of **all** files under `generated/`, `temp_images/`, and the docker data dir (including a no-criteria "delete everything" path), and `/api/storage-stats` discloses filesystem storage details. Both previously skipped every authentication check whenever `NODE_ENV` was exactly `'development'`, so a misconfigured non-production deployment could expose an unauthenticated mass-delete and an information-disclosure endpoint.

## Fix

Gate both endpoints on the app's own authentication policy rather than a raw `NODE_ENV` check:

```ts
const isDevelopment = process.env.NODE_ENV === 'development';
if (isAuthenticationRequired() || !isDevelopment) {
  // require valid session -> 401 otherwise
  // require super_admin outside development -> 403 otherwise
}
```

Access is left open **only** in the local development open-auth mode (`NODE_ENV==='development'` and `isAuthenticationRequired()` false), where the whole app already runs without sessions (the middleware short-circuits) and the in-app dev StorageMonitor needs these endpoints. Everywhere else a valid session is required, with super_admin outside development.

Access truth table:

| NODE_ENV | REQUIRE_AUTH | no session | non-admin | super_admin |
|---|---|---|---|---|
| production | any | 401 | 403 | allow |
| test / staging / unset | any | 401 | 403 | allow |
| development | unset / falsy | allow | allow | allow |
| development | `true` | 401 | allow | allow |

This is **strictly stronger** than the previous `NODE_ENV==='development'`-only gate (a hardened dev with `REQUIRE_AUTH=true` is now protected; production stays protected even if `REQUIRE_AUTH=false` is misconfigured) and does not break the default local dev workflow.

## Validation

- `__tests__/api/dev-cleanup-auth.test.ts` and `__tests__/api/storage-stats-auth.test.ts` pin the full matrix (prod unauth → 401, prod non-admin → 403, non-dev-no-auth → 401, dev+`REQUIRE_AUTH=true` → 401, open-dev → allowed without a session, method guard → 405). 13 tests.
- `npm test -- --runInBand` — 83 suites, 669 passed, 1 skipped
- `npm run build` / `npm run lint` / `git diff --check` — clean (pre-existing lint warnings only)
- Adversarial review built the full NODE_ENV × REQUIRE_AUTH × session truth table and confirmed no real (non-local-dev) deployment permits an unauthenticated destructive or disclosure call, and that the gate is strictly stronger than the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
