### PR TITLE
security: scope localStorage to the signed-in account

### DIFF
--- a/__tests__/hooks/useProjectManagement-startup-gate.test.tsx
+++ b/__tests__/hooks/useProjectManagement-startup-gate.test.tsx
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+
+const mockUseSession = jest.fn();
+jest.mock('next-auth/react', () => ({ useSession: () => mockUseSession() }));
+
+jest.mock('@/lib/session-storage', () => ({
+  SessionStorage: {
+    loadSession: jest.fn(() => null),
+    getSessionAge: jest.fn(() => null),
+    clearSession: jest.fn(),
+  },
+}));
+jest.mock('@/lib/project-storage', () => ({
+  ProjectStorage: {
+    migrateFromTemplateStorage: jest.fn(() => ({ migrated: 0 })),
+    getMostRecentProject: jest.fn(async () => null),
+  },
+}));
+
+import { useProjectManagement } from '@/hooks/useProjectManagement';
+import { SessionStorage } from '@/lib/session-storage';
+import { ProjectStorage } from '@/lib/project-storage';
+
+function makeProps() {
+  return {
+    setPositions: jest.fn(),
+    setEmailConfig: jest.fn(),
+    setUploadedFileUrl: jest.fn(),
+    setUploadedFile: jest.fn(),
+    loadSessionData: jest.fn(async () => {}),
+    uploadToServer: jest.fn(async () => ({})),
+    showToast: jest.fn(),
+    manualSave: jest.fn(async () => ({ success: true })),
+    uploadedFileUrl: null,
+    uploadedFile: null,
+    positions: {},
+    emailConfig: {} as any,
+    tableData: [],
+    automaticTextColorResult: null,
+    clearFile: jest.fn(),
+    clearPositions: jest.fn(),
+    clearDragState: jest.fn(),
+    clearData: jest.fn(),
+  };
+}
+
+describe('useProjectManagement startup restore gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not read localStorage while the auth status is loading', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    renderHook(() => useProjectManagement(makeProps()));
+    // The account guard has not reconciled the owner yet, so no restore.
+    expect(SessionStorage.loadSession).not.toHaveBeenCalled();
+    expect(ProjectStorage.getMostRecentProject).not.toHaveBeenCalled();
+  });
+
+  it('restores once the status settles (authenticated), and only once', async () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    const { rerender } = renderHook(() => useProjectManagement(makeProps()));
+    expect(SessionStorage.loadSession).not.toHaveBeenCalled();
+
+    mockUseSession.mockReturnValue({ data: { user: { id: 'u1' } }, status: 'authenticated' });
+    rerender();
+    // Flush the async startup routine.
+    await Promise.resolve();
+    expect(SessionStorage.loadSession).toHaveBeenCalledTimes(1);
+
+    // A later re-render must not trigger a second restore.
+    rerender();
+    await Promise.resolve();
+    expect(SessionStorage.loadSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores in open (unauthenticated) mode so local single-user use still works', async () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    renderHook(() => useProjectManagement(makeProps()));
+    await Promise.resolve();
+    expect(SessionStorage.loadSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/account-scope.test.ts
+++ b/__tests__/lib/account-scope.test.ts
@@ -1,0 +1,75 @@
+/** @jest-environment jsdom */
+import { guardLocalStorageForUser, __test__ } from '@/lib/storage/account-scope';
+
+const { OWNER_KEY } = __test__;
+
+function seedAppData() {
+  localStorage.setItem('bamboobot_project_v1_abc', JSON.stringify({ name: 'A project' }));
+  localStorage.setItem('bamboobot_template_v1_legacy', JSON.stringify({ name: 'legacy' }));
+  localStorage.setItem('bamboobot_current_session_v1', JSON.stringify({ rows: 1 }));
+  localStorage.setItem('email-queue-session123', JSON.stringify({ items: [] }));
+  localStorage.setItem('pdf-queue-session123', JSON.stringify({ items: [{ data: { Name: 'Recipient' } }] }));
+  localStorage.setItem('bamboobot_onboarding_completed', 'true');
+  localStorage.setItem('bamboobot_tour_completed', 'true');
+}
+
+describe('guardLocalStorageForUser', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('adopts the current account without purging when there is no prior owner', () => {
+    seedAppData();
+    const purged = guardLocalStorageForUser('userA');
+    expect(purged).toBe(false);
+    expect(localStorage.getItem(OWNER_KEY)).toBe('userA');
+    // Existing single-user data is preserved on first adoption.
+    expect(localStorage.getItem('bamboobot_project_v1_abc')).not.toBeNull();
+    expect(localStorage.getItem('bamboobot_current_session_v1')).not.toBeNull();
+  });
+
+  it('does nothing when the same account is seen again', () => {
+    guardLocalStorageForUser('userA');
+    seedAppData();
+    const purged = guardLocalStorageForUser('userA');
+    expect(purged).toBe(false);
+    expect(localStorage.getItem('bamboobot_project_v1_abc')).not.toBeNull();
+  });
+
+  it('purges all app-owned keys when a different account signs in', () => {
+    guardLocalStorageForUser('userA');
+    seedAppData();
+    // An unrelated third-party key must survive.
+    localStorage.setItem('unrelated_key', 'keep me');
+
+    const purged = guardLocalStorageForUser('userB');
+
+    expect(purged).toBe(true);
+    expect(localStorage.getItem(OWNER_KEY)).toBe('userB');
+    expect(localStorage.getItem('bamboobot_project_v1_abc')).toBeNull();
+    expect(localStorage.getItem('bamboobot_template_v1_legacy')).toBeNull();
+    expect(localStorage.getItem('bamboobot_current_session_v1')).toBeNull();
+    expect(localStorage.getItem('email-queue-session123')).toBeNull();
+    expect(localStorage.getItem('pdf-queue-session123')).toBeNull();
+    expect(localStorage.getItem('bamboobot_onboarding_completed')).toBeNull();
+    expect(localStorage.getItem('bamboobot_tour_completed')).toBeNull();
+    expect(localStorage.getItem('unrelated_key')).toBe('keep me');
+  });
+
+  it('is a no-op without a user id (session not ready)', () => {
+    seedAppData();
+    expect(guardLocalStorageForUser(null)).toBe(false);
+    expect(guardLocalStorageForUser(undefined)).toBe(false);
+    expect(localStorage.getItem(OWNER_KEY)).toBeNull();
+    expect(localStorage.getItem('bamboobot_project_v1_abc')).not.toBeNull();
+  });
+
+  it('classifies app-owned keys but not the owner key or unrelated keys', () => {
+    expect(__test__.isAppOwnedKey('bamboobot_project_v1_x')).toBe(true);
+    expect(__test__.isAppOwnedKey('email-queue-abc')).toBe(true);
+    expect(__test__.isAppOwnedKey('pdf-queue-abc')).toBe(true);
+    expect(__test__.isAppOwnedKey('bamboobot_current_session_v1')).toBe(true);
+    expect(__test__.isAppOwnedKey(OWNER_KEY)).toBe(false);
+    expect(__test__.isAppOwnedKey('some_other_app_key')).toBe(false);
+  });
+});

--- a/hooks/useProjectManagement.tsx
+++ b/hooks/useProjectManagement.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
+import { useSession } from "next-auth/react";
 import type { SavedProject } from "@/lib/project-storage";
 import type { EmailConfig, TableData } from "@/types/certificate";
 import { ProjectStorage } from "@/lib/project-storage";
@@ -83,6 +84,9 @@ export function useProjectManagement({
   clearDragState,
   clearData
 }: UseProjectManagementProps): UseProjectManagementReturn {
+  const { status } = useSession();
+  // Ensure the one-shot startup restore reads localStorage only once.
+  const hasLoadedStartupRef = useRef(false);
   // Keep latest mutable references for frequently changing objects to avoid
   // recreating callbacks excessively while still reading fresh values.
   const latestPositionsRef = useRef(positions);
@@ -208,9 +212,17 @@ export function useProjectManagement({
       }
     };
 
-    // Only load on initial mount
+    // Wait until the authentication status is settled before touching
+    // localStorage. On the commit where the session resolves, the account
+    // guard in the page component (registered earlier) has already purged any
+    // data belonging to a different account, so a newly signed-in user never
+    // restores the previous account's session/project. Runs once.
+    if (status === "loading") return;
+    if (hasLoadedStartupRef.current) return;
+    hasLoadedStartupRef.current = true;
     loadStartupData();
   }, [
+    status,
     loadSessionData,
     setEmailConfig,
     loadProjectPositions,

--- a/lib/storage/account-scope.ts
+++ b/lib/storage/account-scope.ts
@@ -1,0 +1,76 @@
+/**
+ * localStorage is shared by every account that signs in on the same browser.
+ * Projects, the working session, email queues and onboarding flags are stored
+ * unscoped, so without a guard a second account would see the first account's
+ * data. This module records which account owns the current localStorage
+ * contents and purges everything when a *different* account signs in.
+ *
+ * On first run for a given browser the owner is unknown; we adopt the current
+ * account without purging so a single user's existing work is never destroyed
+ * by the upgrade. Purging only happens on an actual account change, and we do
+ * not clear on sign-out (that would lose the owner's own projects between their
+ * own sessions — the next different sign-in performs the purge instead).
+ */
+
+const OWNER_KEY = 'bamboobot_ls_owner_v1';
+
+// Prefixes / exact keys of all app-owned localStorage entries.
+const APP_KEY_PREFIXES = [
+  'bamboobot_project_v1_',
+  'bamboobot_template_v1_', // legacy projects
+  'email-queue-',
+  'pdf-queue-', // client PDF queue state (holds recipient row data)
+];
+const APP_EXACT_KEYS = [
+  'bamboobot_current_session_v1',
+  'bamboobot_onboarding_completed',
+  'bamboobot_tour_completed',
+];
+
+function isAppOwnedKey(key: string): boolean {
+  if (key === OWNER_KEY) return false;
+  if (APP_EXACT_KEYS.includes(key)) return true;
+  return APP_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+function purgeAppOwnedKeys(): void {
+  const toRemove: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && isAppOwnedKey(key)) toRemove.push(key);
+  }
+  for (const key of toRemove) localStorage.removeItem(key);
+}
+
+/**
+ * Ensure the browser's localStorage belongs to the given account, clearing it
+ * when the owning account changes. Returns true when a purge was performed.
+ *
+ * Pass the authenticated user id. Pass null/undefined when there is no session
+ * yet — in that case nothing is touched (the guard runs once the user is known).
+ */
+export function guardLocalStorageForUser(userId: string | null | undefined): boolean {
+  if (typeof window === 'undefined' || !userId) return false;
+
+  let previousOwner: string | null = null;
+  try {
+    previousOwner = localStorage.getItem(OWNER_KEY);
+  } catch {
+    return false;
+  }
+
+  if (previousOwner === userId) return false;
+
+  try {
+    // Unknown owner: adopt the current account without discarding existing data.
+    if (previousOwner !== null) {
+      purgeAppOwnedKeys();
+    }
+    localStorage.setItem(OWNER_KEY, userId);
+    return previousOwner !== null;
+  } catch {
+    return false;
+  }
+}
+
+export const __test__ = { OWNER_KEY, isAppOwnedKey };

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -59,6 +59,7 @@ import { UserAvatarDropdown } from "@/components/UserAvatarDropdown";
 import { HelpCircle } from "lucide-react";
 import { useSession } from 'next-auth/react';
 import { useProjectMigration } from "@/hooks/useProjectMigration";
+import { guardLocalStorageForUser } from "@/lib/storage/account-scope";
 import { useUserTier } from "@/hooks/useUserTier";
 import { mapProgressivePdfFiles } from "@/lib/pdf/progressive-results";
 
@@ -71,6 +72,13 @@ export default function HomePage() {
   const [forceMobileAccess, setForceMobileAccess] = useState(false);
   const { data: session } = useSession();
   const { isSuperAdmin } = useUserTier();
+  // Clear localStorage that belonged to a different account before any
+  // localStorage-backed feature (project migration, autosave, email queues)
+  // reads it. Runs before useProjectMigration so a new account never sees the
+  // previous account's projects.
+  useEffect(() => {
+    guardLocalStorageForUser((session?.user as { id?: string } | undefined)?.id ?? null);
+  }, [session?.user]);
   // Check for localStorage projects on first login and offer import
   useProjectMigration();
 


### PR DESCRIPTION
## Summary

Fixes cross-account data leakage in `localStorage`. On a shared browser, a second account could see the first account's projects and recipient data, because the app stores projects, the working session, email queues, the client PDF queue and onboarding flags in `localStorage` with no per-account partitioning.

## Fix

**Account guard (`lib/storage/account-scope.ts`)** — records which account owns the current `localStorage` contents (`bamboobot_ls_owner_v1`) and purges all app-owned keys when a *different* account signs in:

- `bamboobot_project_v1_*` / legacy `bamboobot_template_v1_*` (projects)
- `bamboobot_current_session_v1` (working session)
- `email-queue-*`, `pdf-queue-*` (queues holding recipient row data)
- `bamboobot_onboarding_completed` / `bamboobot_tour_completed`

Wired into `pages/app.tsx` via a `useEffect` keyed on the session user, registered before the other localStorage consumers.

**Safety semantics:**
- First sign-in on a browser adopts existing data *without* purging (a single user's work is never destroyed by the upgrade).
- Same-user re-login is a no-op.
- Sign-out does **not** purge (the owner's own projects survive between their sessions); the purge happens on the next *different* sign-in.

**Startup-restore ordering** — the session/project restore in `useProjectManagement` previously ran on mount, before the session (and therefore the owning account) was known, so it could restore the previous account's data into the UI before the guard ran. It now waits until the auth status is settled — the same commit on which the account guard (registered earlier in the page component) has already purged a different account's data. It still restores normally for same-user reloads and in open (unauthenticated) local mode.

## Validation

- `__tests__/lib/account-scope.test.ts` — same-user preserve, different-user purge (incl. `pdf-queue-`), first-adopt-no-purge, unrelated-key survives, no-userId no-op, key classification.
- `__tests__/hooks/useProjectManagement-startup-gate.test.tsx` — no localStorage read while status is loading; restores exactly once when status settles; still restores in open/unauthenticated mode.
- `npm test -- --runInBand` — 85 suites, 677 passed, 1 skipped
- `npm run build` / `npm run lint` / `git diff --check` — clean (pre-existing lint warnings only)
- Two rounds of adversarial review: the first caught a mount-timing gap (restore ran before the guard) and an uncovered `pdf-queue-*` key; both fixed and re-verified as closed with no regression.

## Out of scope (noted)

IndexedDB `pdf-queue-db` holds generated PDFs; a localStorage guard does not cover it — a reasonable follow-up, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tinkertanker/bamboobot-cert-generator/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->